### PR TITLE
Add back node/zig/rust version caching

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -25,9 +25,7 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install zig
           elif [ "$RUNNER_OS" == "Linux" ]; then
-            # Source Homebrew for Linux (needed as it doesn't happen by default)
-            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-            brew install zig
+            snap install zig --beta --classic
           else
             echo "Unsupported runner OS"
             exit 1
@@ -37,23 +35,6 @@ jobs:
       - name: Validate Flare loads successfully
         shell: pwsh
         run: |
-          # For Linux, make sure Homebrew is in the PATH so we can find Zig
-          if ($env:RUNNER_OS -eq "Linux") {
-            $brewEnv = bash -c "/home/linuxbrew/.linuxbrew/bin/brew shellenv"
-            foreach ($line in $brewEnv) {
-              if ($line -match "export ([^=]+)=(.*)") {
-                $varName = $matches[1]
-                $varValue = $matches[2].Trim('"')
-                [Environment]::SetEnvironmentVariable($varName, $varValue)
-                # Also update the PATH for this session if needed
-                if ($varName -eq "PATH") {
-                  $env:PATH = $varValue
-                }
-              }
-            }
-            Write-Host "Added Homebrew to environment for Linux"
-          }
-
           # Import the module
           Import-Module ${{ github.workspace }}/flare.psm1 -ErrorAction Stop
 
@@ -68,23 +49,6 @@ jobs:
       - name: Validate all Flare pieces work correctly
         shell: pwsh
         run: |
-          # For Linux, make sure Homebrew is in the PATH so we can find Zig
-          if ($env:RUNNER_OS -eq "Linux") {
-            $brewEnv = bash -c "/home/linuxbrew/.linuxbrew/bin/brew shellenv"
-            foreach ($line in $brewEnv) {
-              if ($line -match "export ([^=]+)=(.*)") {
-                $varName = $matches[1]
-                $varValue = $matches[2].Trim('"')
-                [Environment]::SetEnvironmentVariable($varName, $varValue)
-                # Also update the PATH for this session if needed
-                if ($varName -eq "PATH") {
-                  $env:PATH = $varValue
-                }
-              }
-            }
-            Write-Host "Added Homebrew to environment for Linux"
-          }
-
           # Run the testPiecesTiming.ps1 script which will validate all pieces
           # The script will exit with a non-zero code if any piece fails to load or execute correctly
           Write-Host "Running piece validation test on ${{ runner.os }}..."

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Cancel in-progress runs on subsequent pushes to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate on ${{ matrix.os }}
@@ -25,7 +30,7 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install zig
           elif [ "$RUNNER_OS" == "Linux" ]; then
-            snap install zig --beta --classic
+            sudo snap install zig --beta --classic
           else
             echo "Unsupported runner OS"
             exit 1

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,16 +12,48 @@ jobs:
     name: Validate on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Zig
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            choco install zig
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew install zig
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+            # Source Homebrew for Linux (needed as it doesn't happen by default)
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            brew install zig
+          else
+            echo "Unsupported runner OS"
+            exit 1
+          fi
+        shell: bash
+
       - name: Validate Flare loads successfully
         shell: pwsh
         run: |
+          # For Linux, make sure Homebrew is in the PATH so we can find Zig
+          if ($env:RUNNER_OS -eq "Linux") {
+            $brewEnv = bash -c "/home/linuxbrew/.linuxbrew/bin/brew shellenv"
+            foreach ($line in $brewEnv) {
+              if ($line -match "export ([^=]+)=(.*)") {
+                $varName = $matches[1]
+                $varValue = $matches[2].Trim('"')
+                [Environment]::SetEnvironmentVariable($varName, $varValue)
+                # Also update the PATH for this session if needed
+                if ($varName -eq "PATH") {
+                  $env:PATH = $varValue
+                }
+              }
+            }
+            Write-Host "Added Homebrew to environment for Linux"
+          }
+
           # Import the module
           Import-Module ${{ github.workspace }}/flare.psm1 -ErrorAction Stop
 
@@ -36,6 +68,23 @@ jobs:
       - name: Validate all Flare pieces work correctly
         shell: pwsh
         run: |
+          # For Linux, make sure Homebrew is in the PATH so we can find Zig
+          if ($env:RUNNER_OS -eq "Linux") {
+            $brewEnv = bash -c "/home/linuxbrew/.linuxbrew/bin/brew shellenv"
+            foreach ($line in $brewEnv) {
+              if ($line -match "export ([^=]+)=(.*)") {
+                $varName = $matches[1]
+                $varValue = $matches[2].Trim('"')
+                [Environment]::SetEnvironmentVariable($varName, $varValue)
+                # Also update the PATH for this session if needed
+                if ($varName -eq "PATH") {
+                  $env:PATH = $varValue
+                }
+              }
+            }
+            Write-Host "Added Homebrew to environment for Linux"
+          }
+
           # Run the testPiecesTiming.ps1 script which will validate all pieces
           # The script will exit with a non-zero code if any piece fails to load or execute correctly
           Write-Host "Running piece validation test on ${{ runner.os }}..."

--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -99,6 +99,11 @@ function Format-GitStatus {
 
 # Optimized function to get both branch and status in one call
 function Get-GitBranchAndStatus {
+  # Check if git command is available
+  if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) {
+    return @{ Branch = $null; Status = $null }
+  }
+
   # Find git directory using FindFileInParentDirectories (faster than git command)
   $gitDir = FindFileInParentDirectories ".git"
 

--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -1,18 +1,87 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+# Script level variables for caching
+$script:cachedNodeVersion ??= $null
+$script:lastNvmrcTimestamp ??= $null
+$script:workspaceRootPath ??= $null
+
+# Helper function to check if a package.json contains workspace definitions
+function Test-IsWorkspace {
+  param (
+    [string]$PackageJsonPath
+  )
+    
+  try {
+    $packageJson = Get-Content -Path $PackageJsonPath -Raw | ConvertFrom-Json
+    # Check for workspace definitions in various formats
+    return ($null -ne $packageJson.workspaces) -or 
+    ($null -ne $packageJson.workspace) -or
+    ($packageJson.private -eq $true -and $null -ne $packageJson.workspaces)
+  }
+  catch {
+    return $false
+  }
+}
+
 function flare_node {
   $packageJsonPath = FindFileInParentDirectories -fileName "package.json"
+  $nvmrcPath = FindFileInParentDirectories -fileName ".nvmrc"
+
+  # Check if we need to invalidate the cache due to .nvmrc changes
+  if ($null -ne $nvmrcPath) {
+    $currentTimestamp = (Get-Item $nvmrcPath).LastWriteTime
+    if ($script:lastNvmrcTimestamp -ne $currentTimestamp) {
+      $script:cachedNodeVersion = $null
+      $script:lastNvmrcTimestamp = $currentTimestamp
+    }
+  }
 
   if ($null -ne $packageJsonPath) {
-    # Check if we're in the same project
-    if ($packageJsonPath -eq $script:lastNodePath -and $script:lastNodeVersion -ne "") {
-      return "󰎙 $script:lastNodeVersion"
+    # Check if we need to determine or update the workspace root
+    if ($null -eq $script:workspaceRootPath -or -not (Test-Path $script:workspaceRootPath)) {
+      # Check if this is a workspace root
+      if (Test-IsWorkspace -PackageJsonPath $packageJsonPath) {
+        $script:workspaceRootPath = (Split-Path -Parent $packageJsonPath)
+      }
+      else {
+        # Check if we're in a subdirectory of a workspace
+        $dir = (Split-Path -Parent $packageJsonPath)
+        while ($dir) {
+          $potentialRoot = Join-Path $dir "package.json"
+          if (Test-Path $potentialRoot -PathType Leaf) {
+            if (Test-IsWorkspace -PackageJsonPath $potentialRoot) {
+              $script:workspaceRootPath = $dir
+              break
+            }
+          }
+          $dir = Split-Path -Parent $dir
+          if ($null -eq $dir -or $dir -eq "") { break }
+        }
+      }
     }
     
-    $nodeVersion = node -v
-    return "󰎙 $nodeVersion"
+    # Use cached version if available
+    if ($null -eq $script:cachedNodeVersion) {
+      $script:cachedNodeVersion = node -v
+    }
+    return "󰎙 $script:cachedNodeVersion"
   }
   else {
+    # Check if we're still within the previously identified workspace
+    if ($null -ne $script:workspaceRootPath -and (Test-Path $script:workspaceRootPath)) {
+      $currentPath = (Get-Location).Path
+      # If we're still within the workspace, don't invalidate the cache
+      if ($currentPath.StartsWith($script:workspaceRootPath)) {
+        if ($null -ne $script:cachedNodeVersion) {
+          return "󰎙 $script:cachedNodeVersion"
+        }
+      }
+    }
+    
+    # Reset cache when not in a node project and not in a known workspace
+    $script:cachedNodeVersion = $null
+    $script:lastNvmrcTimestamp = $null
+    $script:workspaceRootPath = $null
     return ""
   }
 }

--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -24,6 +24,11 @@ function Test-IsWorkspace {
 }
 
 function flare_node {
+  # Check if node command is available
+  if ($null -eq (Get-Command node -ErrorAction SilentlyContinue)) {
+    return ""
+  }
+
   $packageJsonPath = FindFileInParentDirectories -fileName "package.json"
   $nvmrcPath = FindFileInParentDirectories -fileName ".nvmrc"
 

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -22,6 +22,11 @@ function Test-IsRustWorkspace {
 }
 
 function flare_rust {
+  # Check if rustc command is available
+  if ($null -eq (Get-Command rustc -ErrorAction SilentlyContinue)) {
+    return ""
+  }
+
   $cargoTomlPath = FindFileInParentDirectories -fileName "Cargo.toml"
   $toolchainPath = FindFileInParentDirectories -fileName "rust-toolchain.toml"
   

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -1,13 +1,85 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+# Script level variables for caching
+$script:cachedRustVersion ??= $null
+$script:lastToolchainTimestamp ??= $null
+$script:rustWorkspaceRootPath ??= $null
+
+# Helper function to check if a Cargo.toml contains workspace definitions
+function Test-IsRustWorkspace {
+  param (
+    [string]$CargoTomlPath
+  )
+    
+  try {
+    $content = Get-Content -Path $CargoTomlPath -Raw
+    # Check for [workspace] section in Cargo.toml
+    return $content -match '\[\s*workspace\s*\]'
+  }
+  catch {
+    return $false
+  }
+}
+
 function flare_rust {
   $cargoTomlPath = FindFileInParentDirectories -fileName "Cargo.toml"
+  $toolchainPath = FindFileInParentDirectories -fileName "rust-toolchain.toml"
+  
+  # Check if we need to invalidate the cache due to rust-toolchain.toml changes
+  if ($null -ne $toolchainPath) {
+    $currentTimestamp = (Get-Item $toolchainPath).LastWriteTime
+    if ($script:lastToolchainTimestamp -ne $currentTimestamp) {
+      $script:cachedRustVersion = $null
+      $script:lastToolchainTimestamp = $currentTimestamp
+    }
+  }
 
   if ($null -ne $cargoTomlPath) {
-    $rustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
-    return "󱘗 $rustVersion"
+    # Check if we need to determine or update the workspace root
+    if ($null -eq $script:rustWorkspaceRootPath -or -not (Test-Path $script:rustWorkspaceRootPath)) {
+      # Check if this is a workspace root
+      if (Test-IsRustWorkspace -CargoTomlPath $cargoTomlPath) {
+        $script:rustWorkspaceRootPath = (Split-Path -Parent $cargoTomlPath)
+      }
+      else {
+        # Check if we're in a subdirectory of a workspace
+        $dir = (Split-Path -Parent $cargoTomlPath)
+        while ($dir) {
+          $potentialRoot = Join-Path $dir "Cargo.toml"
+          if (Test-Path $potentialRoot -PathType Leaf) {
+            if (Test-IsRustWorkspace -CargoTomlPath $potentialRoot) {
+              $script:rustWorkspaceRootPath = $dir
+              break
+            }
+          }
+          $dir = Split-Path -Parent $dir
+          if ($null -eq $dir -or $dir -eq "") { break }
+        }
+      }
+    }
+    
+    # Use cached version if available
+    if ($null -eq $script:cachedRustVersion) {
+      $script:cachedRustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+    }
+    return "󱘗 $script:cachedRustVersion"
   }
   else {
+    # Check if we're still within the previously identified workspace
+    if ($null -ne $script:rustWorkspaceRootPath -and (Test-Path $script:rustWorkspaceRootPath)) {
+      $currentPath = (Get-Location).Path
+      # If we're still within the workspace, don't invalidate the cache
+      if ($currentPath.StartsWith($script:rustWorkspaceRootPath)) {
+        if ($null -ne $script:cachedRustVersion) {
+          return "󱘗 $script:cachedRustVersion"
+        }
+      }
+    }
+    
+    # Reset cache when not in a Rust project and not in a known workspace
+    $script:cachedRustVersion = $null
+    $script:lastToolchainTimestamp = $null
+    $script:rustWorkspaceRootPath = $null
     return ""
   }
 }

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -3,6 +3,8 @@
 # Script level variables for caching
 $script:cachedZigVersion ??= $null
 $script:lastBuildZigZonTimestamp ??= $null
+$script:lastBuildZigTimestamp ??= $null
+$script:lastZigProjectPath ??= $null
 
 function flare_zig {
   # Check if zig command is available
@@ -13,13 +15,39 @@ function flare_zig {
   $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
   $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
   
-  # Check if we need to invalidate the cache due to build.zig.zon changes only
+  # Get the current project directory based on build.zig location
+  $currentProjectPath = if ($null -ne $buildZigPath) { Split-Path -Parent $buildZigPath } else { $null }
+  
+  # Check if we've changed projects or if build files have changed
+  $shouldInvalidateCache = $false
+  
+  # Invalidate cache when switching between projects
+  if ($script:lastZigProjectPath -ne $currentProjectPath) {
+    $shouldInvalidateCache = $true
+    $script:lastZigProjectPath = $currentProjectPath
+  }
+  
+  # Check build.zig.zon changes
   if ($null -ne $buildZigZonPath) {
     $currentTimestamp = (Get-Item $buildZigZonPath).LastWriteTime
     if ($script:lastBuildZigZonTimestamp -ne $currentTimestamp) {
-      $script:cachedZigVersion = $null
+      $shouldInvalidateCache = $true
       $script:lastBuildZigZonTimestamp = $currentTimestamp
     }
+  }
+  
+  # Check build.zig changes
+  if ($null -ne $buildZigPath) {
+    $currentTimestamp = (Get-Item $buildZigPath).LastWriteTime
+    if ($script:lastBuildZigTimestamp -ne $currentTimestamp) {
+      $shouldInvalidateCache = $true
+      $script:lastBuildZigTimestamp = $currentTimestamp
+    }
+  }
+  
+  # Invalidate cache if needed
+  if ($shouldInvalidateCache) {
+    $script:cachedZigVersion = $null
   }
 
   if ($null -ne $buildZigPath) {

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -2,25 +2,7 @@
 
 # Script level variables for caching
 $script:cachedZigVersion ??= $null
-$script:lastBuildZigTimestamp ??= $null
 $script:lastBuildZigZonTimestamp ??= $null
-$script:zigWorkspaceRootPath ??= $null
-
-# Helper function to check if this is a potential Zig workspace/multi-module project
-function Test-IsZigWorkspace {
-  param (
-    [string]$BuildZigPath
-  )
-    
-  try {
-    # Check if build.zig.zon exists alongside build.zig
-    $buildZigZonPath = Join-Path (Split-Path -Parent $BuildZigPath) "build.zig.zon"
-    return (Test-Path $buildZigZonPath -PathType Leaf)
-  }
-  catch {
-    return $false
-  }
-}
 
 function flare_zig {
   # Check if zig command is available
@@ -31,53 +13,16 @@ function flare_zig {
   $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
   $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
   
-  # Check if we need to invalidate the cache due to build.zig or build.zig.zon changes
-  $needsCacheInvalidation = $false
-  
-  if ($null -ne $buildZigPath) {
-    $currentTimestamp = (Get-Item $buildZigPath).LastWriteTime
-    if ($script:lastBuildZigTimestamp -ne $currentTimestamp) {
-      $needsCacheInvalidation = $true
-      $script:lastBuildZigTimestamp = $currentTimestamp
-    }
-  }
-  
+  # Check if we need to invalidate the cache due to build.zig.zon changes only
   if ($null -ne $buildZigZonPath) {
     $currentTimestamp = (Get-Item $buildZigZonPath).LastWriteTime
     if ($script:lastBuildZigZonTimestamp -ne $currentTimestamp) {
-      $needsCacheInvalidation = $true
+      $script:cachedZigVersion = $null
       $script:lastBuildZigZonTimestamp = $currentTimestamp
     }
   }
-  
-  if ($needsCacheInvalidation) {
-    $script:cachedZigVersion = $null
-  }
 
   if ($null -ne $buildZigPath) {
-    # Check if we need to determine or update the workspace root
-    if ($null -eq $script:zigWorkspaceRootPath -or -not (Test-Path $script:zigWorkspaceRootPath)) {
-      # Check if this is a workspace root based on build.zig.zon presence
-      if (Test-IsZigWorkspace -BuildZigPath $buildZigPath) {
-        $script:zigWorkspaceRootPath = (Split-Path -Parent $buildZigPath)
-      }
-      else {
-        # Check if we're in a subdirectory of a workspace
-        $dir = (Split-Path -Parent $buildZigPath)
-        while ($dir) {
-          $potentialBuildZig = Join-Path $dir "build.zig"
-          if (Test-Path $potentialBuildZig -PathType Leaf) {
-            if (Test-IsZigWorkspace -BuildZigPath $potentialBuildZig) {
-              $script:zigWorkspaceRootPath = $dir
-              break
-            }
-          }
-          $dir = Split-Path -Parent $dir
-          if ($null -eq $dir -or $dir -eq "") { break }
-        }
-      }
-    }
-    
     # Use cached version if available
     if ($null -eq $script:cachedZigVersion) {
       $script:cachedZigVersion = zig version
@@ -85,22 +30,9 @@ function flare_zig {
     return " $script:cachedZigVersion"
   }
   else {
-    # Check if we're still within the previously identified workspace
-    if ($null -ne $script:zigWorkspaceRootPath -and (Test-Path $script:zigWorkspaceRootPath)) {
-      $currentPath = (Get-Location).Path
-      # If we're still within the workspace, don't invalidate the cache
-      if ($currentPath.StartsWith($script:zigWorkspaceRootPath)) {
-        if ($null -ne $script:cachedZigVersion) {
-          return " $script:cachedZigVersion"
-        }
-      }
-    }
-    
-    # Reset cache when not in a Zig project and not in a known workspace
+    # Reset cache when not in a Zig project
     $script:cachedZigVersion = $null
-    $script:lastBuildZigTimestamp = $null
     $script:lastBuildZigZonTimestamp = $null
-    $script:zigWorkspaceRootPath = $null
     return ""
   }
 }

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -23,6 +23,11 @@ function Test-IsZigWorkspace {
 }
 
 function flare_zig {
+  # Check if zig command is available
+  if ($null -eq (Get-Command zig -ErrorAction SilentlyContinue)) {
+    return ""
+  }
+
   $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
   $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
   

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -1,14 +1,101 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+# Script level variables for caching
+$script:cachedZigVersion ??= $null
+$script:lastBuildZigTimestamp ??= $null
+$script:lastBuildZigZonTimestamp ??= $null
+$script:zigWorkspaceRootPath ??= $null
+
+# Helper function to check if this is a potential Zig workspace/multi-module project
+function Test-IsZigWorkspace {
+  param (
+    [string]$BuildZigPath
+  )
+    
+  try {
+    # Check if build.zig.zon exists alongside build.zig
+    $buildZigZonPath = Join-Path (Split-Path -Parent $BuildZigPath) "build.zig.zon"
+    return (Test-Path $buildZigZonPath -PathType Leaf)
+  }
+  catch {
+    return $false
+  }
+}
+
 function flare_zig {
   $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
+  $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
+  
+  # Check if we need to invalidate the cache due to build.zig or build.zig.zon changes
+  $needsCacheInvalidation = $false
+  
+  if ($null -ne $buildZigPath) {
+    $currentTimestamp = (Get-Item $buildZigPath).LastWriteTime
+    if ($script:lastBuildZigTimestamp -ne $currentTimestamp) {
+      $needsCacheInvalidation = $true
+      $script:lastBuildZigTimestamp = $currentTimestamp
+    }
+  }
+  
+  if ($null -ne $buildZigZonPath) {
+    $currentTimestamp = (Get-Item $buildZigZonPath).LastWriteTime
+    if ($script:lastBuildZigZonTimestamp -ne $currentTimestamp) {
+      $needsCacheInvalidation = $true
+      $script:lastBuildZigZonTimestamp = $currentTimestamp
+    }
+  }
+  
+  if ($needsCacheInvalidation) {
+    $script:cachedZigVersion = $null
+  }
 
   if ($null -ne $buildZigPath) {
-    # Cache miss, get the version
-    $zigVersion = zig version
-    return " $zigVersion"
+    # Check if we need to determine or update the workspace root
+    if ($null -eq $script:zigWorkspaceRootPath -or -not (Test-Path $script:zigWorkspaceRootPath)) {
+      # Check if this is a workspace root based on build.zig.zon presence
+      if (Test-IsZigWorkspace -BuildZigPath $buildZigPath) {
+        $script:zigWorkspaceRootPath = (Split-Path -Parent $buildZigPath)
+      }
+      else {
+        # Check if we're in a subdirectory of a workspace
+        $dir = (Split-Path -Parent $buildZigPath)
+        while ($dir) {
+          $potentialBuildZig = Join-Path $dir "build.zig"
+          if (Test-Path $potentialBuildZig -PathType Leaf) {
+            if (Test-IsZigWorkspace -BuildZigPath $potentialBuildZig) {
+              $script:zigWorkspaceRootPath = $dir
+              break
+            }
+          }
+          $dir = Split-Path -Parent $dir
+          if ($null -eq $dir -or $dir -eq "") { break }
+        }
+      }
+    }
+    
+    # Use cached version if available
+    if ($null -eq $script:cachedZigVersion) {
+      $script:cachedZigVersion = zig version
+    }
+    return " $script:cachedZigVersion"
   }
   else {
+    # Check if we're still within the previously identified workspace
+    if ($null -ne $script:zigWorkspaceRootPath -and (Test-Path $script:zigWorkspaceRootPath)) {
+      $currentPath = (Get-Location).Path
+      # If we're still within the workspace, don't invalidate the cache
+      if ($currentPath.StartsWith($script:zigWorkspaceRootPath)) {
+        if ($null -ne $script:cachedZigVersion) {
+          return " $script:cachedZigVersion"
+        }
+      }
+    }
+    
+    # Reset cache when not in a Zig project and not in a known workspace
+    $script:cachedZigVersion = $null
+    $script:lastBuildZigTimestamp = $null
+    $script:lastBuildZigZonTimestamp = $null
+    $script:zigWorkspaceRootPath = $null
     return ""
   }
 }


### PR DESCRIPTION
Seeing calculations for versions take 50ms, so we
cannot query version values every time.

Added detection for version specific file types.

Attempt at workspace detection.
