### PR TITLE
Move Get-Command checks

### DIFF
--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -24,11 +24,6 @@ function Test-IsWorkspace {
 }
 
 function flare_node {
-  # Check if node command is available
-  if ($null -eq (Get-Command node -ErrorAction SilentlyContinue)) {
-    return ""
-  }
-
   $packageJsonPath = FindFileInParentDirectories -fileName "package.json"
   $nvmrcPath = FindFileInParentDirectories -fileName ".nvmrc"
 
@@ -67,7 +62,13 @@ function flare_node {
     
     # Use cached version if available
     if ($null -eq $script:cachedNodeVersion) {
-      $script:cachedNodeVersion = node -v
+      # Check if the node command is available
+      if (Get-Command node -ErrorAction SilentlyContinue) {
+        $script:cachedNodeVersion = node -v
+      }
+      else {
+        $script:cachedNodeVersion = ""
+      }
     }
     return "󰎙 $script:cachedNodeVersion"
   }

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -6,11 +6,6 @@ $script:lastToolchainTimestamp ??= $null
 $script:rustWorkspaceRootPath ??= $null
 
 function flare_rust {
-  # Check if rustc command is available
-  if ($null -eq (Get-Command rustc -ErrorAction SilentlyContinue)) {
-    return ""
-  }
-
   $cargoTomlPath = FindFileInParentDirectories -fileName "Cargo.toml"
   $toolchainPath = FindFileInParentDirectories -fileName "rust-toolchain.toml"
   
@@ -26,7 +21,13 @@ function flare_rust {
   if ($null -ne $cargoTomlPath) {    
     # Use cached version if available
     if ($null -eq $script:cachedRustVersion) {
-      $script:cachedRustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+      # Check if the rustc command is available
+      if (Get-Command rustc -ErrorAction SilentlyContinue) {
+        $script:cachedRustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+      }
+      else {
+        $script:cachedRustVersion = ""
+      }
     }
 
     $script:rustWorkspaceRootPath = Split-Path -Path $cargoTomlPath -Parent

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -5,22 +5,6 @@ $script:cachedRustVersion ??= $null
 $script:lastToolchainTimestamp ??= $null
 $script:rustWorkspaceRootPath ??= $null
 
-# Helper function to check if a Cargo.toml contains workspace definitions
-function Test-IsRustWorkspace {
-  param (
-    [string]$CargoTomlPath
-  )
-    
-  try {
-    $content = Get-Content -Path $CargoTomlPath -Raw
-    # Check for [workspace] section in Cargo.toml
-    return $content -match '\[\s*workspace\s*\]'
-  }
-  catch {
-    return $false
-  }
-}
-
 function flare_rust {
   # Check if rustc command is available
   if ($null -eq (Get-Command rustc -ErrorAction SilentlyContinue)) {
@@ -39,34 +23,13 @@ function flare_rust {
     }
   }
 
-  if ($null -ne $cargoTomlPath) {
-    # Check if we need to determine or update the workspace root
-    if ($null -eq $script:rustWorkspaceRootPath -or -not (Test-Path $script:rustWorkspaceRootPath)) {
-      # Check if this is a workspace root
-      if (Test-IsRustWorkspace -CargoTomlPath $cargoTomlPath) {
-        $script:rustWorkspaceRootPath = (Split-Path -Parent $cargoTomlPath)
-      }
-      else {
-        # Check if we're in a subdirectory of a workspace
-        $dir = (Split-Path -Parent $cargoTomlPath)
-        while ($dir) {
-          $potentialRoot = Join-Path $dir "Cargo.toml"
-          if (Test-Path $potentialRoot -PathType Leaf) {
-            if (Test-IsRustWorkspace -CargoTomlPath $potentialRoot) {
-              $script:rustWorkspaceRootPath = $dir
-              break
-            }
-          }
-          $dir = Split-Path -Parent $dir
-          if ($null -eq $dir -or $dir -eq "") { break }
-        }
-      }
-    }
-    
+  if ($null -ne $cargoTomlPath) {    
     # Use cached version if available
     if ($null -eq $script:cachedRustVersion) {
       $script:cachedRustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
     }
+
+    $script:rustWorkspaceRootPath = Split-Path -Path $cargoTomlPath -Parent
     return "󱘗 $script:cachedRustVersion"
   }
   else {

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -7,11 +7,6 @@ $script:lastBuildZigTimestamp ??= $null
 $script:lastZigProjectPath ??= $null
 
 function flare_zig {
-  # Check if zig command is available
-  if ($null -eq (Get-Command zig -ErrorAction SilentlyContinue)) {
-    return ""
-  }
-
   $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
   $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
   
@@ -35,9 +30,16 @@ function flare_zig {
 
   if ($null -ne $buildZigPath) {
     # Use cached version if available
-    if ($null -eq $script:cachedZigVersion) {
-      $script:cachedZigVersion = zig version
+    if (($null -eq $script:cachedZigVersion)) {
+      # Check if the zig command is available
+      if (Get-Command zig -ErrorAction SilentlyContinue) {
+        $script:cachedZigVersion = zig version
+      }
+      else {
+        $script:cachedZigVersion = ""
+      }
     }
+
     return " $script:cachedZigVersion"
   }
   else {

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -18,36 +18,19 @@ function flare_zig {
   # Get the current project directory based on build.zig location
   $currentProjectPath = if ($null -ne $buildZigPath) { Split-Path -Parent $buildZigPath } else { $null }
   
-  # Check if we've changed projects or if build files have changed
-  $shouldInvalidateCache = $false
-  
   # Invalidate cache when switching between projects
   if ($script:lastZigProjectPath -ne $currentProjectPath) {
-    $shouldInvalidateCache = $true
+    $script:cachedZigVersion = $null
     $script:lastZigProjectPath = $currentProjectPath
   }
   
-  # Check build.zig.zon changes
+  # Check build.zig.zon changes and invalidate cache if needed
   if ($null -ne $buildZigZonPath) {
     $currentTimestamp = (Get-Item $buildZigZonPath).LastWriteTime
     if ($script:lastBuildZigZonTimestamp -ne $currentTimestamp) {
-      $shouldInvalidateCache = $true
+      $script:cachedZigVersion = $null
       $script:lastBuildZigZonTimestamp = $currentTimestamp
     }
-  }
-  
-  # Check build.zig changes
-  if ($null -ne $buildZigPath) {
-    $currentTimestamp = (Get-Item $buildZigPath).LastWriteTime
-    if ($script:lastBuildZigTimestamp -ne $currentTimestamp) {
-      $shouldInvalidateCache = $true
-      $script:lastBuildZigTimestamp = $currentTimestamp
-    }
-  }
-  
-  # Invalidate cache if needed
-  if ($shouldInvalidateCache) {
-    $script:cachedZigVersion = $null
   }
 
   if ($null -ne $buildZigPath) {


### PR DESCRIPTION
Get-Command does a search for the command on Windows, which appears to be surprisingly slow (I'm seeing ~150ms+).

Apparently, everything else is super fast. So only checking the command when we would need to run it ends up much faster than checking for it each time we go to update the prompt.