### PR TITLE
Add background thread for status updates

### DIFF
--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -217,11 +217,6 @@ function flare_init_git {
           return  # Skip if a job is already running
         }
 
-        if ($null -ne $global:flare_gitStatusJob) {
-          $results = Receive-Job -Job $job
-          Write-Host $results
-        }
-
         $global:flare_gitStatusJob = Start-ThreadJob -ArgumentList $eventArgs, $global:flare_cachedGitInfo -ScriptBlock {
           param($evt, $gitInfoCache)
           $path = $evt.FullPath
@@ -237,7 +232,6 @@ function flare_init_git {
               try {
                 $p = Get-Process -Id $proc.ProcessId -ErrorAction SilentlyContinue
                 if ($p) {
-                  Write-Output "Waiting for git process $($p.Id) to exit..."
                   $p.WaitForExit()
                 }
               }
@@ -253,7 +247,6 @@ function flare_init_git {
             foreach ($proc in $gitProcs) {
               try {
                 # Wait for the process to exit
-                Write-Output "Waiting for git process $($proc.PID) to exit..."
                 while (Get-Process -Id $proc.PID -ErrorAction SilentlyContinue) {
                   Start-Sleep -Milliseconds 100
                 }

--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -391,7 +391,7 @@ function flare_git {
 
   # Update or initialize git watcher
   Update-GitWatcher -RepoPath $repoPath
-    
+
   # Use cached data if available, otherwise get fresh data
   if ($global:flare_cachedGitInfo.Branch) {
     return Format-GitOutput -Branch $global:flare_cachedGitInfo.Branch -Status $global:flare_cachedGitInfo.Status


### PR DESCRIPTION
What I didn't realize is the the file updates come in on a queue being sequentially processed.

We were spinning up `git status` for every single file change which for large number of changes easily bottlenecks the CPU.

This instead moves the `git status` call to a thread job. It still goes through the queue, but if an existing thread job is running, we just drop the new event. This appears to be working.

This also attempts to check if there's already a git child process running. What can happen is the `git status` runs and finishes while another git process is still modifying files, we'll spin `git status` again, which can hit high CPU usage (but not as bad as before). The assumption is if you ran `git something` in the current PowerShell session "hopefully" we can detect it (it's difficult to check it if actually works other than manually watching task manager).

The downside here, is the prompt is more frequently out-of-sync since the background thread removes a ton of the blocking the event callback alone had.

Trying to come up with ideas to have an acceptable delay to better be in sync.