### PR TITLE
Add async update

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "PowerShell: Launch Script",
+      "type": "PowerShell",
+      "request": "launch",
+      "script": "Import-Module \"${workspaceFolder}/flare.psm1\"",
+      "args": []
+    }
+  ]
+}

--- a/flare.psm1
+++ b/flare.psm1
@@ -192,6 +192,8 @@ function Update-BackgroundThreadPieces {
         
         # Store the entire package
         $results["_package_$timestamp"] = $resultsPackage
+        $defaultRunspace.Events.GenerateEvent('Flare.Redraw', $_, $null, $null)
+        Write-Output 'Flare.Redraw event triggered'
     } -ArgumentList $backgroundThreadPieces, $global:flare_resultCache, $mainRunspace, $timestamp
     
     # Update the last job timestamp
@@ -234,7 +236,7 @@ function Get-PromptTopLine {
     "$left$defaultStyle$(' ' * $spaces)$right"
 }
 
-Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
+Register-EngineEvent -SourceIdentifier Flare.Redraw -Action {
     # Check if there are any background jobs to process
     if ($global:flare_backgroundJobs.Count -eq 0) {
         return
@@ -318,6 +320,10 @@ Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
         [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
         $global:flare_redrawing = $false
     }
+}
+
+Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
+    New-Event -SourceIdentifier Flare.Redraw -Sender $Sender
 }
 
 # Register a cleanup event handler for when the module is removed

--- a/flare.psm1
+++ b/flare.psm1
@@ -348,7 +348,7 @@ function Prompt {
 
     Set-PSReadLineOption -ExtraPromptLineCount 1
 
-    "$topLine`n$line "
+    "`r$topLine`n$line "
 }
 
 # Add module exports

--- a/flare.psm1
+++ b/flare.psm1
@@ -105,7 +105,12 @@ function Get-RightPrompt {
             $foreground = $foregroundStyles['brightBlack']
             $separatorColor = $foregroundStyles.Values[($foregroundStyles.Count - $(if (($count - 1) -gt 0) { $count - 1 } else { $count })) % $foregroundStyles.Count]
             $separator = "$separatorColor$(if (($count - 1) -gt 0) { "$background$global:flare_promptSeparatorsRight" } else { "$($backgroundStyles['default'])$global:flare_promptTailRight" })"
-            $right = "$background$foreground $pieceResult $separator$right"
+            $right = "$pieceResult $separator$right"
+            $icon = Get-Variable -Name "flare_icons_$pieceName" -Scope Global -ValueOnly -ErrorAction SilentlyContinue
+            if ($icon) {
+                $right = "$icon $right"
+            }
+            $right = "$background$foreground $right"
             $count += 1
         }
     }

--- a/flare.psm1
+++ b/flare.psm1
@@ -290,7 +290,7 @@ Register-EngineEvent -SourceIdentifier Flare.Redraw -Action {
     }
     
     # Remove completed jobs from our tracking array
-    $global:flare_backgroundJobs = $global:flare_backgroundJobs | Where-Object { $_.State -eq 'Running' }
+    $global:flare_backgroundJobs = ($global:flare_backgroundJobs | Where-Object { $_.State -eq 'Running' })
 
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
     $comparisonPieces = $allPieces | Where-Object { $_ -notin $global:flare_mainThread }

--- a/flare.psm1
+++ b/flare.psm1
@@ -243,18 +243,22 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
 }
 
 function Prompt {
-    if ($PWD -ne $global:flare_lastDirectory) {
-        if ($global:flare_backgroundJob -and $global:flare_backgroundJob.State -eq 'Running') {
-            # Stop the background job if the directory changes
-            Stop-Job $global:flare_backgroundJob -Force -ErrorAction SilentlyContinue
-            $global:flare_backgroundJob = $null
-        }
+    if ($global:flare_lastDirectory) {
+        if (-not $PWD.Path.StartsWith($global:flare_lastDirectory.Path)) {
+            if ($global:flare_backgroundJob -and $global:flare_backgroundJob.State -eq 'Running') {
+                # Stop the background job if the directory changes
+                Stop-Job $global:flare_backgroundJob -Force -ErrorAction SilentlyContinue
+                $global:flare_backgroundJob = $null
+            }
 
-        $global:flare_lastDirectory = $PWD
-        # Clear the last render cache when the directory changes
-        $global:flare_lastRenderCache.Clear()
-        $global:flare_resultCache.Clear()
+            # Clear the last render cache when the directory changes
+            $global:flare_lastRenderCache.Clear()
+            $global:flare_resultCache.Clear()
+        }
     }
+
+    $global:flare_lastDirectory = $PWD
+
 
     $topLine = Get-PromptTopLine
     $line = Get-PromptLine

--- a/flare.psm1
+++ b/flare.psm1
@@ -290,7 +290,7 @@ Register-EngineEvent -SourceIdentifier Flare.Redraw -Action {
     }
     
     # Remove completed jobs from our tracking array
-    $global:flare_backgroundJobs = ($global:flare_backgroundJobs | Where-Object { $_.State -eq 'Running' })
+    $global:flare_backgroundJobs = ($global:flare_backgroundJobs | Where-Object { $_.State -eq 'Running' }) ?? @()
 
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
     $comparisonPieces = $allPieces | Where-Object { $_ -notin $global:flare_mainThread }

--- a/pieces/git_fast.ps1
+++ b/pieces/git_fast.ps1
@@ -1,0 +1,45 @@
+. $PSScriptRoot/../utils/fileUtils.ps1
+. $PSScriptRoot/git.ps1
+
+function flare_git_fast {
+  # Get repository path
+  $repoPath = Get-GitRepoPath
+  
+  # Not in a git repo
+  if (-not $repoPath) { 
+    return '' 
+  }
+
+  # Fast branch detection by directly reading the git HEAD file
+  $gitDir = Join-Path $repoPath '.git'
+  $headFile = Join-Path $gitDir 'HEAD'
+
+  if (Test-Path $headFile) {
+    $headContent = Get-Content -Path $headFile -Raw
+    
+    # Check if we have a direct reference to a branch
+    if ($headContent -match 'ref: refs/heads/(.+)$') {
+      return $Matches[1]
+    }
+    # If in a special state (detached HEAD, rebase, merge, etc.)
+    elseif ($headContent -match '^([0-9a-f]+)') {
+      # Check for rebase/merge/cherry-pick in progress
+      if (Test-Path (Join-Path $gitDir 'rebase-merge')) {
+        return 'REBASE'
+      }
+      elseif (Test-Path (Join-Path $gitDir 'rebase-apply')) {
+        return 'REBASE'
+      }
+      elseif (Test-Path (Join-Path $gitDir 'MERGE_HEAD')) {
+        return 'MERGE'
+      }
+      elseif (Test-Path (Join-Path $gitDir 'CHERRY_PICK_HEAD')) {
+        return 'CHERRY'
+      }
+      # Detached HEAD state - use abbreviated commit hash
+      return 'DETACHED@' + $headContent.Substring(0, 7)
+    }
+  }
+
+  return ''
+}

--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -1,93 +1,14 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
-# Script level variables for caching
-$script:cachedNodeVersion ??= $null
-$script:lastNvmrcTimestamp ??= $null
-$script:workspaceRootPath ??= $null
-
-# Helper function to check if a package.json contains workspace definitions
-function Test-IsWorkspace {
-  param (
-    [string]$PackageJsonPath
-  )
-    
-  try {
-    $packageJson = Get-Content -Path $PackageJsonPath -Raw | ConvertFrom-Json
-    # Check for workspace definitions in various formats
-    return ($null -ne $packageJson.workspaces) -or 
-    ($null -ne $packageJson.workspace) -or
-    ($packageJson.private -eq $true -and $null -ne $packageJson.workspaces)
-  }
-  catch {
-    return $false
-  }
-}
-
 function flare_node {
-  $packageJsonPath = FindFileInParentDirectories -fileName "package.json"
-  $nvmrcPath = FindFileInParentDirectories -fileName ".nvmrc"
+  $packageJsonPath = FindFileInParentDirectories -fileName 'package.json'
 
-  # Check if we need to invalidate the cache due to .nvmrc changes
-  if ($null -ne $nvmrcPath) {
-    $currentTimestamp = (Get-Item $nvmrcPath).LastWriteTime
-    if ($script:lastNvmrcTimestamp -ne $currentTimestamp) {
-      $script:cachedNodeVersion = $null
-      $script:lastNvmrcTimestamp = $currentTimestamp
+  if ($packageJsonPath) {
+    # Check if the node command is available
+    if (Get-Command node -ErrorAction SilentlyContinue) {
+      return node -v
     }
   }
 
-  if ($null -ne $packageJsonPath) {
-    # Check if we need to determine or update the workspace root
-    if ($null -eq $script:workspaceRootPath -or -not (Test-Path $script:workspaceRootPath)) {
-      # Check if this is a workspace root
-      if (Test-IsWorkspace -PackageJsonPath $packageJsonPath) {
-        $script:workspaceRootPath = (Split-Path -Parent $packageJsonPath)
-      }
-      else {
-        # Check if we're in a subdirectory of a workspace
-        $dir = (Split-Path -Parent $packageJsonPath)
-        while ($dir) {
-          $potentialRoot = Join-Path $dir "package.json"
-          if (Test-Path $potentialRoot -PathType Leaf) {
-            if (Test-IsWorkspace -PackageJsonPath $potentialRoot) {
-              $script:workspaceRootPath = $dir
-              break
-            }
-          }
-          $dir = Split-Path -Parent $dir
-          if ($null -eq $dir -or $dir -eq "") { break }
-        }
-      }
-    }
-    
-    # Use cached version if available
-    if ($null -eq $script:cachedNodeVersion) {
-      # Check if the node command is available
-      if (Get-Command node -ErrorAction SilentlyContinue) {
-        $script:cachedNodeVersion = node -v
-      }
-      else {
-        $script:cachedNodeVersion = ""
-      }
-    }
-    return "$script:cachedNodeVersion"
-  }
-  else {
-    # Check if we're still within the previously identified workspace
-    if ($null -ne $script:workspaceRootPath -and (Test-Path $script:workspaceRootPath)) {
-      $currentPath = (Get-Location).Path
-      # If we're still within the workspace, don't invalidate the cache
-      if ($currentPath.StartsWith($script:workspaceRootPath)) {
-        if ($null -ne $script:cachedNodeVersion) {
-          return "$script:cachedNodeVersion"
-        }
-      }
-    }
-    
-    # Reset cache when not in a node project and not in a known workspace
-    $script:cachedNodeVersion = $null
-    $script:lastNvmrcTimestamp = $null
-    $script:workspaceRootPath = $null
-    return ""
-  }
+  return ''
 }

--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -70,7 +70,7 @@ function flare_node {
         $script:cachedNodeVersion = ""
       }
     }
-    return "󰎙 $script:cachedNodeVersion"
+    return "$script:cachedNodeVersion"
   }
   else {
     # Check if we're still within the previously identified workspace
@@ -79,7 +79,7 @@ function flare_node {
       # If we're still within the workspace, don't invalidate the cache
       if ($currentPath.StartsWith($script:workspaceRootPath)) {
         if ($null -ne $script:cachedNodeVersion) {
-          return "󰎙 $script:cachedNodeVersion"
+          return "$script:cachedNodeVersion"
         }
       }
     }

--- a/pieces/pwd.ps1
+++ b/pieces/pwd.ps1
@@ -24,5 +24,5 @@ function flare_pwd {
   }
   
   # Join the parts back together
-  " $($result -join [System.IO.Path]::DirectorySeparatorChar)"
+  "$($result -join [System.IO.Path]::DirectorySeparatorChar)"
 }

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -31,7 +31,7 @@ function flare_rust {
     }
 
     $script:rustWorkspaceRootPath = Split-Path -Path $cargoTomlPath -Parent
-    return "󱘗 $script:cachedRustVersion"
+    return "$script:cachedRustVersion"
   }
   else {
     # Check if we're still within the previously identified workspace
@@ -40,7 +40,7 @@ function flare_rust {
       # If we're still within the workspace, don't invalidate the cache
       if ($currentPath.StartsWith($script:rustWorkspaceRootPath)) {
         if ($null -ne $script:cachedRustVersion) {
-          return "󱘗 $script:cachedRustVersion"
+          return "$script:cachedRustVersion"
         }
       }
     }

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -1,54 +1,15 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
-# Script level variables for caching
-$script:cachedRustVersion ??= $null
-$script:lastToolchainTimestamp ??= $null
-$script:rustWorkspaceRootPath ??= $null
-
 function flare_rust {
-  $cargoTomlPath = FindFileInParentDirectories -fileName "Cargo.toml"
-  $toolchainPath = FindFileInParentDirectories -fileName "rust-toolchain.toml"
-  
-  # Check if we need to invalidate the cache due to rust-toolchain.toml changes
-  if ($null -ne $toolchainPath) {
-    $currentTimestamp = (Get-Item $toolchainPath).LastWriteTime
-    if ($script:lastToolchainTimestamp -ne $currentTimestamp) {
-      $script:cachedRustVersion = $null
-      $script:lastToolchainTimestamp = $currentTimestamp
+  $cargoTomlPath = FindFileInParentDirectories -fileName 'Cargo.toml'
+  $toolchainPath = FindFileInParentDirectories -fileName 'rust-toolchain.toml'
+
+  if ($cargoTomlPath -or $toolchainPath) {
+    # Check if the rustc command is available
+    if (Get-Command rustc -ErrorAction SilentlyContinue) {
+      return rustc --version | Select-String -Pattern '(\d+\.\d+\.\d+)' | ForEach-Object { $_.Matches.Groups[1].Value }
     }
   }
 
-  if ($null -ne $cargoTomlPath) {    
-    # Use cached version if available
-    if ($null -eq $script:cachedRustVersion) {
-      # Check if the rustc command is available
-      if (Get-Command rustc -ErrorAction SilentlyContinue) {
-        $script:cachedRustVersion = rustc --version | Select-String -Pattern "(\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
-      }
-      else {
-        $script:cachedRustVersion = ""
-      }
-    }
-
-    $script:rustWorkspaceRootPath = Split-Path -Path $cargoTomlPath -Parent
-    return "$script:cachedRustVersion"
-  }
-  else {
-    # Check if we're still within the previously identified workspace
-    if ($null -ne $script:rustWorkspaceRootPath -and (Test-Path $script:rustWorkspaceRootPath)) {
-      $currentPath = (Get-Location).Path
-      # If we're still within the workspace, don't invalidate the cache
-      if ($currentPath.StartsWith($script:rustWorkspaceRootPath)) {
-        if ($null -ne $script:cachedRustVersion) {
-          return "$script:cachedRustVersion"
-        }
-      }
-    }
-    
-    # Reset cache when not in a Rust project and not in a known workspace
-    $script:cachedRustVersion = $null
-    $script:lastToolchainTimestamp = $null
-    $script:rustWorkspaceRootPath = $null
-    return ""
-  }
+  return ''
 }

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -1,51 +1,14 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
-# Script level variables for caching
-$script:cachedZigVersion ??= $null
-$script:lastBuildZigZonTimestamp ??= $null
-$script:lastBuildZigTimestamp ??= $null
-$script:lastZigProjectPath ??= $null
-
 function flare_zig {
-  $buildZigPath = FindFileInParentDirectories -fileName "build.zig"
-  $buildZigZonPath = FindFileInParentDirectories -fileName "build.zig.zon"
-  
-  # Get the current project directory based on build.zig location
-  $currentProjectPath = if ($null -ne $buildZigPath) { Split-Path -Parent $buildZigPath } else { $null }
-  
-  # Invalidate cache when switching between projects
-  if ($script:lastZigProjectPath -ne $currentProjectPath) {
-    $script:cachedZigVersion = $null
-    $script:lastZigProjectPath = $currentProjectPath
-  }
-  
-  # Check build.zig.zon changes and invalidate cache if needed
-  if ($null -ne $buildZigZonPath) {
-    $currentTimestamp = (Get-Item $buildZigZonPath).LastWriteTime
-    if ($script:lastBuildZigZonTimestamp -ne $currentTimestamp) {
-      $script:cachedZigVersion = $null
-      $script:lastBuildZigZonTimestamp = $currentTimestamp
+  $buildZigPath = FindFileInParentDirectories -fileName 'build.zig'
+  $buildZigZonPath = FindFileInParentDirectories -fileName 'build.zig.zon'
+
+  if ($buildZigPath -or $buildZigZonPath) {
+    if (Get-Command zig -ErrorAction SilentlyContinue) {
+      zig version
     }
   }
 
-  if ($null -ne $buildZigPath) {
-    # Use cached version if available
-    if (($null -eq $script:cachedZigVersion)) {
-      # Check if the zig command is available
-      if (Get-Command zig -ErrorAction SilentlyContinue) {
-        $script:cachedZigVersion = zig version
-      }
-      else {
-        $script:cachedZigVersion = ""
-      }
-    }
-
-    return "$script:cachedZigVersion"
-  }
-  else {
-    # Reset cache when not in a Zig project
-    $script:cachedZigVersion = $null
-    $script:lastBuildZigZonTimestamp = $null
-    return ""
-  }
+  return ''
 }

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -40,7 +40,7 @@ function flare_zig {
       }
     }
 
-    return " $script:cachedZigVersion"
+    return "$script:cachedZigVersion"
   }
   else {
     # Reset cache when not in a Zig project

--- a/promptSymbols.ps1
+++ b/promptSymbols.ps1
@@ -4,29 +4,34 @@
 #$global:flare_promptSeparatorsRight ??= ""
 #$global:flare_promptHeadRight ??= ""
 
-$global:flare_promptSeparatorsLeft ??= ""
-$global:flare_promptHeadLeft ??= ""
-$global:flare_promptTailLeft ??= "░▒▓"
-$global:flare_promptSeparatorsRight ??= ""
-$global:flare_promptHeadRight ??= ""
-$global:flare_promptTailRight ??= "▓▒░"
-$global:flare_topPrefix ??= "╭─"
-$global:flare_bottomPrefix ??= "╰─"
-$global:flare_promptArrow ??= ""
+$global:flare_promptSeparatorsLeft ??= ''
+$global:flare_promptHeadLeft ??= ''
+$global:flare_promptTailLeft ??= '░▒▓'
+$global:flare_promptSeparatorsRight ??= ''
+$global:flare_promptHeadRight ??= ''
+$global:flare_promptTailRight ??= '▓▒░'
+$global:flare_topPrefix ??= '╭─'
+$global:flare_bottomPrefix ??= '╰─'
+$global:flare_promptArrow ??= ''
 
-$global:flare_gitIcon ??= ""
+$global:flare_icons_pwd ??= ''
+$global:flare_icons_git ??= ''
+$global:flare_icons_zig ??= ''
+$global:flare_icons_rust ??= ''
+$global:flare_icons_node ??= '󰎙'
+
 $global:flare_dateFormat ??= 'HH:mm:ss'
 
 $global:flare_leftPieces ??= @(
-  "os"
-  "pwd"
-  "git"
+  'os'
+  'pwd'
+  'git'
 )
 
 $global:flare_rightPieces ??= @(
-  "date"
-  "node"
-  "rust"
-  "zig"
-  "lastCommand"
+  'date'
+  'node'
+  'rust'
+  'zig'
+  'lastCommand'
 )

--- a/utils/invokeUtils.ps1
+++ b/utils/invokeUtils.ps1
@@ -6,11 +6,16 @@ function Invoke-FlarePiece {
   )
   try {
     # Source the piece script file
-    . "$PiecesPath/$PieceName.ps1"
+    if (Test-Path "$PiecesPath/$PieceName.ps1") {
+      . "$PiecesPath/$PieceName.ps1"
+    }
         
     # Prepare to execute the command
     $command = "flare_$PieceName"
-        
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+      return ''
+    }
+    
     # Time the execution
     $timing = [System.Diagnostics.Stopwatch]::StartNew()
     $result = & $command -ErrorAction SilentlyContinue

--- a/utils/invokeUtils.ps1
+++ b/utils/invokeUtils.ps1
@@ -1,0 +1,51 @@
+function Invoke-FlarePiece {
+  param(
+    [string]$PieceName,
+    [string]$PiecesPath = "$PSScriptRoot/../pieces",
+    [bool]$IncludeTime = $false
+  )
+  try {
+    # Source the piece script file
+    . "$PiecesPath/$PieceName.ps1"
+        
+    # Prepare to execute the command
+    $command = "flare_$PieceName"
+        
+    # Time the execution
+    $timing = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = & $command -ErrorAction SilentlyContinue
+    $timing.Stop()
+        
+    # Format the result based on user settings
+    if ($IncludeTime -and $result -ne '') {
+      $elapsed = [math]::Round($timing.Elapsed.TotalMilliseconds, 2)
+      return "$result ($elapsed ms)"
+    }
+    else {
+      return $result
+    }
+  }
+  catch {
+    return ''
+  }
+}
+
+
+function Get-PromptPieceResults {
+  param(
+    [string[]]$Pieces,
+    [string]$PiecesPath = "$PSScriptRoot/../pieces",
+    [bool]$IncludeTime = $false
+  )
+    
+  $results = @{}
+    
+  foreach ($piece in $Pieces) {
+    $result = Invoke-FlarePiece -PieceName $piece -PiecesPath $PiecesPath -IncludeTime $IncludeTime
+    if ($result) {
+      $results[$piece] = $result
+    }
+  }
+    
+  return $results
+}


### PR DESCRIPTION
This removes the [FileSystemWriter](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher?view=net-9.0) and a lot of the component self caching.

- FileSystemWriter worked great, except in extremely massive monorepos (possibly with file paths greater than MAX_PATH, so who knows the real issue).

The async rerender appears to only work on Windows. We hooked up some fun ways to trigger an event from a Job [thanks stackoverflow](https://stackoverflow.com/a/77073299/1111028)!

This is trying to do something like tide where it creates a background job to calculate updates and trigger a repaint.

It also introduces "_fast" prompt parts, where if we have something like `git`, it'll find `flare_git_fast` to do an upfront render and queue the `git` to run on the background job to then replace the `git_fast` results. This lets us populate the prompt bar with as much info before rerender.

Rerender does not work on Unix systems based on how the keyboarding works in PowerShell on Unix. The queued redraw cannot run until after a keypress on Unix since the keyboard read is a blocking operation in the implementation.