### PR TITLE
Avoid rendering right prompt when screen is too small

### DIFF
--- a/flare.psm1
+++ b/flare.psm1
@@ -222,10 +222,12 @@ function Get-PromptTopLine {
     # Get the window width and subtract the current cursor position
     $spaces = $Host.UI.RawUI.WindowSize.Width - ($($left -replace $escapeRegex).Length + $($right -replace $escapeRegex).Length)
 
-    # Ensure spaces is not negative
-    if ($spaces -lt 0) { $spaces = 0 }
-
-    "$left$defaultStyle$(' ' * $spaces)$right"
+    if ($spaces -lt 0) { 
+      # Not enough space to also have right prompt
+      "$left"
+    } else {
+      "$left$defaultStyle$(' ' * $spaces)$right"
+    }
 }
 
 Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {


### PR DESCRIPTION
If the left + right prompt length is greater than the terminal width, we should not show the right prompt