### PR TITLE
Fix prompt input blocking

### DIFF
--- a/flare.psm1
+++ b/flare.psm1
@@ -257,7 +257,11 @@ function Test-FlareBackgroundJobTerminalState {
         [object]$Job
     )
 
-    $Job.State.ToString() -in @('Completed', 'Failed', 'Stopped')
+    $Job.State -in @(
+        [System.Management.Automation.JobState]::Completed,
+        [System.Management.Automation.JobState]::Failed,
+        [System.Management.Automation.JobState]::Stopped
+    )
 }
 
 Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {

--- a/flare.psm1
+++ b/flare.psm1
@@ -251,14 +251,24 @@ function Get-PromptTopLine {
     }
 }
 
+function Test-FlareBackgroundJobTerminalState {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Job
+    )
+
+    $Job.State.ToString() -in @('Completed', 'Failed', 'Stopped')
+}
+
 Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
     # Check if there are any background jobs to process
     if ($global:flare_backgroundJobs.Count -eq 0) {
         return
     }
 
-    # Process completed jobs
-    $completedJobs = $global:flare_backgroundJobs | Where-Object { $_.State -ne 'Running' }
+    # Only terminal jobs are safe to wait on. Queued jobs can sit in NotStarted,
+    # and Wait-Job on those would block the interactive runspace.
+    $completedJobs = $global:flare_backgroundJobs | Where-Object { Test-FlareBackgroundJobTerminalState $_ }
     if ($completedJobs.Count -eq 0) {
         return
     }
@@ -329,7 +339,7 @@ Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
 
     # Remove completed jobs from our tracking collection
     $newBag = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
-    foreach ($job in ($global:flare_backgroundJobs | Where-Object { $_.State -eq 'Running' })) {
+    foreach ($job in ($global:flare_backgroundJobs | Where-Object { -not (Test-FlareBackgroundJobTerminalState $_) })) {
         $newBag.Add($job)
     }
     $global:flare_backgroundJobs = $newBag

--- a/testBackgroundJobs.ps1
+++ b/testBackgroundJobs.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+
+# Validate that the idle redraw handler only processes terminal background jobs.
+# Treating queued jobs as completed can block keyboard input when Wait-Job runs.
+
+$module = Import-Module "$PSScriptRoot/flare.psm1" -Force -PassThru -ErrorAction Stop
+
+$testCases = @(
+    @{ State = 'Completed'; Expected = $true },
+    @{ State = 'Failed'; Expected = $true },
+    @{ State = 'Stopped'; Expected = $true },
+    @{ State = 'NotStarted'; Expected = $false },
+    @{ State = 'Running'; Expected = $false },
+    @{ State = 'Blocked'; Expected = $false },
+    @{ State = 'Suspended'; Expected = $false },
+    @{ State = 'Disconnected'; Expected = $false },
+    @{ State = 'Suspending'; Expected = $false },
+    @{ State = 'Stopping'; Expected = $false },
+    @{ State = 'AtBreakpoint'; Expected = $false }
+)
+
+$allTestsPassed = $true
+
+foreach ($testCase in $testCases) {
+    $actual = & $module {
+        param($state)
+
+        $jobState = [System.Management.Automation.JobState]::$state
+        Test-FlareBackgroundJobTerminalState ([pscustomobject]@{ State = $jobState })
+    } $testCase.State
+
+    if ($actual -eq $testCase.Expected) {
+        Write-Host "PASS Background job state '$($testCase.State)' classified correctly"
+    }
+    else {
+        Write-Host "FAIL Background job state '$($testCase.State)' expected '$($testCase.Expected)' but got '$actual'" -ForegroundColor Red
+        $allTestsPassed = $false
+    }
+}
+
+if (-not $allTestsPassed) {
+    exit 1
+}

--- a/testPiecesTiming.ps1
+++ b/testPiecesTiming.ps1
@@ -134,6 +134,13 @@ catch {
     exit 1
 }
 
+Write-Host 'Testing background job state handling...' -ForegroundColor Cyan
+& "$PSScriptRoot/testBackgroundJobs.ps1"
+if (-not $?) {
+    exit 1
+}
+Write-Host ''
+
 Write-Host 'Testing individual pieces performance in controlled environment...'
 Write-Host "Running $Iterations iterations per piece..."
 Write-Host ''


### PR DESCRIPTION
Queued background jobs can enter non-terminal states such as `NotStarted` while PowerShell is waiting for thread job capacity. The idle redraw handler was treating every non-running job as safe to process, which meant a queued job could be passed to `Wait-Job` and block keyboard input in the interactive runspace.

This change makes background job handling explicit: only terminal states (`Completed`, `Failed`, and `Stopped`) are processed and waited on, while queued or otherwise active states remain tracked for a later idle pass. It also adds a focused regression script covering every PowerShell `JobState` value so the terminal-state classification stays intentional.

Validation run locally:

- `pwsh -NoProfile -File .\testBackgroundJobs.ps1`
- `pwsh -NoProfile -Command "Import-Module .\flare.psm1 -Force -ErrorAction Stop; 'import ok'"`