### PR TITLE
Fix git prompt status refresh

### DIFF
--- a/flare.psm1
+++ b/flare.psm1
@@ -6,8 +6,14 @@ $global:flare_resultCache = [System.Collections.Concurrent.ConcurrentDictionary[
 # Cache for what was last rendered, to be used to compare with result cache
 $global:flare_lastRenderCache = @{}
 
+# Last refresh time for fast pieces that update the cache synchronously.
+$global:flare_fastRefreshTimestamps = [System.Collections.Concurrent.ConcurrentDictionary[string, datetime]]::new()
+
 # Items we can calculate on the main thread, but should also ignore when comparing changes from the background job
 $global:flare_mainThread = @('os', 'date', 'lastCommand', 'pwd')
+
+# Fast pieces that should refresh every prompt because their state can change without touching prompt caches.
+$global:flare_alwaysRefreshFastPieces ??= @('git')
 
 # Use a concurrent collection to track all background jobs
 $global:flare_backgroundJobs = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
@@ -142,7 +148,11 @@ function Update-MainThreadPieces {
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
     # Find the intersection of all prompt pieces and main thread items
     $mainThreadPieces = $allPieces | Where-Object { $_ -in $global:flare_mainThread }
-    $mainThreadPieces += $allPieces | Where-Object { ($_ -notin $global:flare_mainThread) -and (-not $global:flare_resultCache.ContainsKey($_)) } | ForEach-Object { "${_}_fast" }
+    $mainThreadPieces += $allPieces | Where-Object {
+        ($_ -notin $global:flare_mainThread) -and
+        (($_ -in $global:flare_alwaysRefreshFastPieces) -or (-not $global:flare_resultCache.ContainsKey($_)))
+    } | ForEach-Object { "${_}_fast" }
+    $mainThreadPieces = $mainThreadPieces | Select-Object -Unique
 
     $mainThreadResults = Get-PromptPieceResults -Pieces $mainThreadPieces
 
@@ -151,9 +161,12 @@ function Update-MainThreadPieces {
         if ($piece -like '*_fast') {
             $pieceFast = $piece
             $piece = $piece -replace '_fast', ''
-            # Fast results are only valid when we don't have a cached actual result.
-            if (-not $global:flare_resultCache.ContainsKey($piece)) {
+            # Most fast results are fallbacks; selected pieces use them for cheap, synchronous freshness.
+            if (($piece -in $global:flare_alwaysRefreshFastPieces) -or (-not $global:flare_resultCache.ContainsKey($piece))) {
                 $global:flare_resultCache[$piece] = $mainThreadResults[$pieceFast]
+                if ($piece -in $global:flare_alwaysRefreshFastPieces) {
+                    $global:flare_fastRefreshTimestamps[$piece] = Get-Date
+                }
             }
         }
         else {
@@ -166,6 +179,9 @@ function Update-BackgroundThreadPieces {
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
     # Find the intersection of all prompt pieces and main thread items
     $backgroundThreadPieces = $allPieces | Where-Object { $_ -notin $global:flare_mainThread }
+    if ($backgroundThreadPieces.Count -eq 0) {
+        return
+    }
 
     # Capture the working directory at the time the job is created.
     # Background jobs run in another runspace and may not inherit the caller's location,
@@ -319,6 +335,11 @@ Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
         if ($newestPackage) {
             # Apply the results to the main cache
             foreach ($piece in $newestPackage.Results.Keys) {
+                $lastFastRefresh = $null
+                if ($global:flare_fastRefreshTimestamps.TryGetValue($piece, [ref]$lastFastRefresh) -and $newestPackage.Timestamp -lt $lastFastRefresh) {
+                    continue
+                }
+
                 $global:flare_resultCache[$piece] = $newestPackage.Results[$piece]
             }
 
@@ -408,6 +429,7 @@ function Prompt {
             # Clear the last render cache when the directory changes
             $global:flare_lastRenderCache.Clear()
             $global:flare_resultCache.Clear()
+            $global:flare_fastRefreshTimestamps.Clear()
 
             # Cancel any in-flight background jobs created for the previous directory.
             # If we don't, a slower job can complete after cd and OnIdle can reapply

--- a/flare.psm1
+++ b/flare.psm1
@@ -13,7 +13,9 @@ $global:flare_fastRefreshTimestamps = [System.Collections.Concurrent.ConcurrentD
 $global:flare_mainThread = @('os', 'date', 'lastCommand', 'pwd')
 
 # Fast pieces that should refresh every prompt because their state can change without touching prompt caches.
-$global:flare_alwaysRefreshFastPieces ??= @('git')
+if ($null -eq $global:flare_alwaysRefreshFastPieces) {
+    $global:flare_alwaysRefreshFastPieces = @('git')
+}
 
 # Use a concurrent collection to track all background jobs
 $global:flare_backgroundJobs = [System.Collections.Concurrent.ConcurrentBag[object]]::new()

--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -86,7 +86,7 @@ function flare_git {
     }
 
     # Get git status and counts like tide
-    $stat = git --no-optional-locks status --porcelain --untracked-files=normal 2>$null
+    $stat = git --no-optional-locks status --porcelain --untracked-files=all 2>$null
     
     # Count stashes
     $stashList = git stash list 2>$null

--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -86,7 +86,7 @@ function flare_git {
     }
 
     # Get git status and counts like tide
-    $stat = git --no-optional-locks status --porcelain 2>$null
+    $stat = git --no-optional-locks status --porcelain --untracked-files=normal 2>$null
     
     # Count stashes
     $stashList = git stash list 2>$null

--- a/pieces/git_fast.ps1
+++ b/pieces/git_fast.ps1
@@ -221,6 +221,7 @@ function Get-GitIndexEntries {
 
       $mtime = Read-GitIndexUInt32 $bytes ($offset + 8)
       $size = Read-GitIndexUInt32 $bytes ($offset + 36)
+      $objectId = [System.BitConverter]::ToString($bytes, $offset + 40, 20).Replace('-', '').ToLowerInvariant()
       $flags = Read-GitIndexUInt16 $bytes ($offset + 60)
       $pathLength = $flags -band 0x0fff
       $pathStart = $offset + 62
@@ -248,8 +249,9 @@ function Get-GitIndexEntries {
 
       $path = [System.Text.Encoding]::UTF8.GetString($bytes, $pathStart, $pathEnd - $pathStart)
       $entries[$path] = @{
-        MTime = $mtime
-        Size  = $size
+        MTime = [uint64]$mtime
+        Oid   = $objectId
+        Size  = [uint64]$size
       }
 
       while (($pathEnd -lt $bytes.Length) -and ($bytes[$pathEnd] -ne 0)) {
@@ -262,7 +264,9 @@ function Get-GitIndexEntries {
       }
     }
   }
-  catch { }
+  catch [System.IO.IOException], [System.UnauthorizedAccessException], [System.Security.SecurityException] {
+    return @{}
+  }
 
   return $entries
 }
@@ -273,8 +277,120 @@ function ConvertTo-GitRelativePath {
     [string]$Path
   )
 
-  $relativePath = [System.IO.Path]::GetRelativePath($RepoPath, $Path)
+  $repoFullPath = [System.IO.Path]::GetFullPath($RepoPath).TrimEnd(@(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar
+  ))
+  $pathFullPath = [System.IO.Path]::GetFullPath($Path)
+  $comparison = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+    [System.StringComparison]::OrdinalIgnoreCase
+  }
+  else {
+    [System.StringComparison]::Ordinal
+  }
+  $prefix = "$repoFullPath$([System.IO.Path]::DirectorySeparatorChar)"
+
+  if ($pathFullPath.StartsWith($prefix, $comparison)) {
+    $relativePath = $pathFullPath.Substring($prefix.Length)
+  }
+  else {
+    $repoUriPath = if ($repoFullPath.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+      $repoFullPath
+    }
+    else {
+      "$repoFullPath$([System.IO.Path]::DirectorySeparatorChar)"
+    }
+    $repoUri = [System.Uri]::new($repoUriPath)
+    $pathUri = [System.Uri]::new($pathFullPath)
+    $relativePath = [System.Uri]::UnescapeDataString($repoUri.MakeRelativeUri($pathUri).ToString())
+  }
+
   return ($relativePath -replace '\\', '/')
+}
+
+function Get-GitBlobSha1ForContent {
+  param([byte[]]$Content)
+
+  $header = [System.Text.Encoding]::ASCII.GetBytes("blob $($Content.Length)")
+  $bytes = [byte[]]::new($header.Length + 1 + $Content.Length)
+  [System.Buffer]::BlockCopy($header, 0, $bytes, 0, $header.Length)
+  $bytes[$header.Length] = 0
+  [System.Buffer]::BlockCopy($Content, 0, $bytes, $header.Length + 1, $Content.Length)
+
+  $sha1 = [System.Security.Cryptography.SHA1]::Create()
+  try {
+    return [System.BitConverter]::ToString($sha1.ComputeHash($bytes)).Replace('-', '').ToLowerInvariant()
+  }
+  finally {
+    $sha1.Dispose()
+  }
+}
+
+function Get-GitBlobSha1Candidates {
+  param([System.IO.FileInfo]$File)
+
+  try {
+    $content = [System.IO.File]::ReadAllBytes($File.FullName)
+    $hashes = @(Get-GitBlobSha1ForContent $content)
+
+    $text = [System.Text.Encoding]::UTF8.GetString($content)
+    if ($text.Contains("`r`n")) {
+      $normalizedContent = [System.Text.Encoding]::UTF8.GetBytes(($text -replace "`r`n", "`n"))
+      $hashes += Get-GitBlobSha1ForContent $normalizedContent
+    }
+
+    return $hashes | Select-Object -Unique
+  }
+  catch [System.Text.DecoderFallbackException] {
+    return @()
+  }
+  catch [System.IO.IOException], [System.UnauthorizedAccessException], [System.Security.SecurityException] {
+    return @()
+  }
+}
+
+function Get-UntrackedFileCount {
+  param(
+    [System.IO.DirectoryInfo]$Directory,
+    [int]$Limit = 1000
+  )
+
+  $count = 0
+  $stack = [System.Collections.Generic.Stack[System.IO.DirectoryInfo]]::new()
+  $stack.Push($Directory)
+
+  while (($stack.Count -gt 0) -and ($count -lt $Limit)) {
+    $currentDirectory = $stack.Pop()
+    try {
+      foreach ($file in $currentDirectory.EnumerateFiles()) {
+        if ($file.Name -eq '.git') {
+          continue
+        }
+
+        $count += 1
+        if ($count -ge $Limit) {
+          break
+        }
+      }
+
+      if ($count -ge $Limit) {
+        break
+      }
+
+      foreach ($childDirectory in $currentDirectory.EnumerateDirectories()) {
+        if (($childDirectory.Name -eq '.git') -or (($childDirectory.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+          continue
+        }
+
+        $stack.Push($childDirectory)
+      }
+    }
+    catch [System.IO.IOException], [System.UnauthorizedAccessException], [System.Security.SecurityException] {
+      continue
+    }
+  }
+
+  return $count
 }
 
 function Get-GitFastWorkingTreeStatus {
@@ -293,7 +409,7 @@ function Get-GitFastWorkingTreeStatus {
     return $status
   }
 
-  $comparer = if ($IsWindows) {
+  $comparer = if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
     [System.StringComparer]::OrdinalIgnoreCase
   }
   else {
@@ -319,7 +435,7 @@ function Get-GitFastWorkingTreeStatus {
     $directory = $stack.Pop()
     try {
       foreach ($childDirectory in $directory.EnumerateDirectories()) {
-        if ($childDirectory.Name -eq '.git') {
+        if (($childDirectory.Name -eq '.git') -or (($childDirectory.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
           continue
         }
 
@@ -328,7 +444,7 @@ function Get-GitFastWorkingTreeStatus {
           $stack.Push($childDirectory)
         }
         else {
-          $status.Untracked += 1
+          $status.Untracked += Get-UntrackedFileCount $childDirectory
         }
       }
 
@@ -340,8 +456,15 @@ function Get-GitFastWorkingTreeStatus {
         $relativePath = ConvertTo-GitRelativePath $RepoPath $file.FullName
         if ($trackedPaths.Contains($relativePath)) {
           $entry = $indexEntries[$relativePath]
-          if ([uint64]$file.Length -ne [uint64]$entry.Size) {
+          $lastWriteSeconds = [uint64][Math]::Floor(($file.LastWriteTimeUtc - [datetime]'1970-01-01Z').TotalSeconds)
+          if ([uint64]$file.Length -ne $entry.Size) {
             $status.Dirty += 1
+          }
+          elseif ($lastWriteSeconds -ne $entry.MTime) {
+            $blobShaCandidates = @(Get-GitBlobSha1Candidates $file)
+            if (($blobShaCandidates.Count -eq 0) -or ($entry.Oid -notin $blobShaCandidates)) {
+              $status.Dirty += 1
+            }
           }
         }
         else {
@@ -349,7 +472,9 @@ function Get-GitFastWorkingTreeStatus {
         }
       }
     }
-    catch { }
+    catch [System.IO.IOException], [System.UnauthorizedAccessException], [System.Security.SecurityException] {
+      continue
+    }
   }
 
   return $status

--- a/pieces/git_fast.ps1
+++ b/pieces/git_fast.ps1
@@ -166,6 +166,195 @@ function Get-StashCount {
   return 0
 }
 
+function Read-GitIndexUInt32 {
+  param(
+    [byte[]]$Bytes,
+    [int]$Offset
+  )
+
+  return [uint32](
+    ([uint32]$Bytes[$Offset] -shl 24) -bor
+    ([uint32]$Bytes[$Offset + 1] -shl 16) -bor
+    ([uint32]$Bytes[$Offset + 2] -shl 8) -bor
+    [uint32]$Bytes[$Offset + 3]
+  )
+}
+
+function Read-GitIndexUInt16 {
+  param(
+    [byte[]]$Bytes,
+    [int]$Offset
+  )
+
+  return [uint16]((([uint16]$Bytes[$Offset]) -shl 8) -bor [uint16]$Bytes[$Offset + 1])
+}
+
+function Get-GitIndexEntries {
+  param([string]$GitDir)
+
+  $entries = @{}
+  $indexPath = Join-Path $GitDir 'index'
+  if (-not (Test-Path $indexPath -PathType Leaf)) {
+    return $entries
+  }
+
+  try {
+    $bytes = [System.IO.File]::ReadAllBytes($indexPath)
+    if ($bytes.Length -lt 12) {
+      return $entries
+    }
+
+    $signature = [System.Text.Encoding]::ASCII.GetString($bytes, 0, 4)
+    $version = Read-GitIndexUInt32 $bytes 4
+    if (($signature -ne 'DIRC') -or ($version -notin @(2, 3))) {
+      return $entries
+    }
+
+    $count = Read-GitIndexUInt32 $bytes 8
+    $offset = 12
+
+    for ($i = 0; $i -lt $count; $i++) {
+      $entryStart = $offset
+      if ($offset + 62 -gt $bytes.Length) {
+        break
+      }
+
+      $mtime = Read-GitIndexUInt32 $bytes ($offset + 8)
+      $size = Read-GitIndexUInt32 $bytes ($offset + 36)
+      $flags = Read-GitIndexUInt16 $bytes ($offset + 60)
+      $pathLength = $flags -band 0x0fff
+      $pathStart = $offset + 62
+      if (($flags -band 0x4000) -ne 0) {
+        $pathStart += 2
+      }
+
+      if ($pathStart -ge $bytes.Length) {
+        break
+      }
+
+      $pathEnd = $pathStart
+      if ($pathLength -eq 0x0fff) {
+        while (($pathEnd -lt $bytes.Length) -and ($bytes[$pathEnd] -ne 0)) {
+          $pathEnd++
+        }
+      }
+      else {
+        $pathEnd = [Math]::Min($pathStart + $pathLength, $bytes.Length)
+      }
+
+      if ($pathEnd -le $pathStart) {
+        break
+      }
+
+      $path = [System.Text.Encoding]::UTF8.GetString($bytes, $pathStart, $pathEnd - $pathStart)
+      $entries[$path] = @{
+        MTime = $mtime
+        Size  = $size
+      }
+
+      while (($pathEnd -lt $bytes.Length) -and ($bytes[$pathEnd] -ne 0)) {
+        $pathEnd++
+      }
+
+      $offset = $pathEnd + 1
+      while ((($offset - $entryStart) % 8 -ne 0) -and ($offset -lt $bytes.Length)) {
+        $offset++
+      }
+    }
+  }
+  catch { }
+
+  return $entries
+}
+
+function ConvertTo-GitRelativePath {
+  param(
+    [string]$RepoPath,
+    [string]$Path
+  )
+
+  $relativePath = [System.IO.Path]::GetRelativePath($RepoPath, $Path)
+  return ($relativePath -replace '\\', '/')
+}
+
+function Get-GitFastWorkingTreeStatus {
+  param(
+    [string]$RepoPath,
+    [string]$GitDir
+  )
+
+  $status = @{
+    Dirty     = 0
+    Untracked = 0
+  }
+
+  $indexEntries = Get-GitIndexEntries $GitDir
+  if ($indexEntries.Count -eq 0) {
+    return $status
+  }
+
+  $comparer = if ($IsWindows) {
+    [System.StringComparer]::OrdinalIgnoreCase
+  }
+  else {
+    [System.StringComparer]::Ordinal
+  }
+
+  $trackedPaths = [System.Collections.Generic.HashSet[string]]::new($comparer)
+  $trackedDirectories = [System.Collections.Generic.HashSet[string]]::new($comparer)
+
+  foreach ($path in $indexEntries.Keys) {
+    $null = $trackedPaths.Add($path)
+    $directory = [System.IO.Path]::GetDirectoryName($path) -replace '\\', '/'
+    while ($directory) {
+      $null = $trackedDirectories.Add($directory)
+      $directory = [System.IO.Path]::GetDirectoryName($directory) -replace '\\', '/'
+    }
+  }
+
+  $stack = [System.Collections.Generic.Stack[System.IO.DirectoryInfo]]::new()
+  $stack.Push([System.IO.DirectoryInfo]::new($RepoPath))
+
+  while ($stack.Count -gt 0) {
+    $directory = $stack.Pop()
+    try {
+      foreach ($childDirectory in $directory.EnumerateDirectories()) {
+        if ($childDirectory.Name -eq '.git') {
+          continue
+        }
+
+        $relativePath = ConvertTo-GitRelativePath $RepoPath $childDirectory.FullName
+        if ($trackedDirectories.Contains($relativePath)) {
+          $stack.Push($childDirectory)
+        }
+        else {
+          $status.Untracked += 1
+        }
+      }
+
+      foreach ($file in $directory.EnumerateFiles()) {
+        if ($file.Name -eq '.git') {
+          continue
+        }
+
+        $relativePath = ConvertTo-GitRelativePath $RepoPath $file.FullName
+        if ($trackedPaths.Contains($relativePath)) {
+          $entry = $indexEntries[$relativePath]
+          if ([uint64]$file.Length -ne [uint64]$entry.Size) {
+            $status.Dirty += 1
+          }
+        }
+        else {
+          $status.Untracked += 1
+        }
+      }
+    }
+    catch { }
+  }
+
+  return $status
+}
+
 function flare_git_fast {
   # Get repository info
   $repoInfo = Get-GitRepoInfo
@@ -222,10 +411,21 @@ function flare_git_fast {
       }
     }
     
+    $workingTreeStatus = Get-GitFastWorkingTreeStatus $repoInfo.RepoPath $gitDir
+
+    # Add status indicators (matching tide order where available: stash, dirty, untracked)
+    $statusParts = @()
+
     # Add stash indicator
     $stashCount = Get-StashCount $gitDir
     if ($stashCount -gt 0) {
-      $output += " *$stashCount"
+      $statusParts += "*$stashCount"
+    }
+    if ($workingTreeStatus.Dirty -gt 0) { $statusParts += "!$($workingTreeStatus.Dirty)" }
+    if ($workingTreeStatus.Untracked -gt 0) { $statusParts += "?$($workingTreeStatus.Untracked)" }
+
+    if ($statusParts.Count -gt 0) {
+      $output += " " + ($statusParts -join " ")
     }
     
     return $output

--- a/testBackgroundJobs.ps1
+++ b/testBackgroundJobs.ps1
@@ -38,7 +38,6 @@ foreach ($testCase in $testCases) {
     }
 }
 
-$originalLocation = Get-Location
 $originalLeftPieces = @($global:flare_leftPieces)
 $originalRightPieces = @($global:flare_rightPieces)
 $originalPath = $env:PATH
@@ -90,7 +89,7 @@ try {
     }
 }
 finally {
-    Set-Location $originalLocation
+    Pop-Location -ErrorAction SilentlyContinue
     $env:PATH = $originalPath
     $global:flare_leftPieces = $originalLeftPieces
     $global:flare_rightPieces = $originalRightPieces

--- a/testBackgroundJobs.ps1
+++ b/testBackgroundJobs.ps1
@@ -38,6 +38,68 @@ foreach ($testCase in $testCases) {
     }
 }
 
+$originalLocation = Get-Location
+$originalLeftPieces = @($global:flare_leftPieces)
+$originalRightPieces = @($global:flare_rightPieces)
+$originalPath = $env:PATH
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "flare-git-cache-test-$(Get-Random)"
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+try {
+    Push-Location $tempDir
+    git init --quiet
+    git config user.name 'Flare Test'
+    git config user.email 'test@example.com'
+    git checkout -b main 2>$null | Out-Null
+    'Initial commit' | Out-File -FilePath 'README.md' -Encoding utf8
+    git add README.md
+    git commit -m 'Initial commit' --quiet
+
+    $env:PATH = ''
+
+    & $module {
+        $global:flare_leftPieces = @('git')
+        $global:flare_rightPieces = @()
+        $global:flare_resultCache.Clear()
+        $global:flare_lastRenderCache.Clear()
+        $global:flare_fastRefreshTimestamps.Clear()
+    }
+
+    $cleanGitStatus = & $module {
+        Update-MainThreadPieces
+        $global:flare_resultCache['git']
+    }
+
+    'Untracked content' | Out-File -FilePath 'untracked.txt' -Encoding utf8
+
+    $untrackedGitStatus = & $module {
+        Update-MainThreadPieces
+        $global:flare_resultCache['git']
+    }
+
+    if ($cleanGitStatus -match '\?1') {
+        Write-Host "FAIL Clean git prompt unexpectedly reported untracked files: '$cleanGitStatus'" -ForegroundColor Red
+        $allTestsPassed = $false
+    }
+    elseif ($untrackedGitStatus -match '\?1') {
+        Write-Host 'PASS Git prompt cache refreshes untracked files immediately'
+    }
+    else {
+        Write-Host "FAIL Git prompt cache did not report untracked files. Actual: '$untrackedGitStatus'" -ForegroundColor Red
+        $allTestsPassed = $false
+    }
+}
+finally {
+    Set-Location $originalLocation
+    $env:PATH = $originalPath
+    $global:flare_leftPieces = $originalLeftPieces
+    $global:flare_rightPieces = $originalRightPieces
+    $global:flare_resultCache.Clear()
+    $global:flare_lastRenderCache.Clear()
+    $global:flare_fastRefreshTimestamps.Clear()
+    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
 if (-not $allTestsPassed) {
     exit 1
 }


### PR DESCRIPTION
Git prompt status could stay stale after creating a new file because the prompt reused cached git output while the full git piece refreshed asynchronously. This updates the fast git path so untracked files are detected immediately without spawning `git`, preserving the intent that `flare_git_fast` only reads local `.git` and working tree state.

Changes include:
- Refresh selected fast pieces, currently `git`, on every prompt render.
- Prevent older background git results from overwriting newer synchronous fast results.
- Parse the git index and scan the working tree in `flare_git_fast` for quick dirty/untracked indicators.
- Add a regression that clears `PATH` before the fast refresh to prove it does not depend on the `git` command.

Validation:
- `pwsh -NoProfile -File .\testBackgroundJobs.ps1`
- `pwsh -NoProfile -File .\testGitStates.ps1`
- `pwsh -NoProfile -File .\testPiecesTiming.ps1 -Iterations 5`
- `git --no-pager diff --check`