### PR TITLE
Simplify background prompt refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Very little exists here at the moment, and development may be slower as I use Wi
 
 Currently, it uses base16 colors that it inherits from your terminal.
 
+## Prompt Refresh
+
+Flare renders cheap pieces and available `*_fast` variants synchronously. Slow pieces are evaluated by one long-lived, in-process PowerShell runspace so prompt rendering never waits for them.
+
+The worker performs one refresh at a time and retains only the newest pending request. Results are matched to both a request ID and working directory before they can update the prompt. While a refresh is pending, Flare keeps compatible last-known slow data and overlays fresh fast data. A changed result redraws the prompt when PowerShell is idle.
+
+Slow refreshes do not have a timeout. A hung refresh delays later slow updates, but the prompt remains responsive and does not create additional workers.
+
+Module removal and shell exit request asynchronous worker shutdown, so teardown never waits for an active slow piece.
+
 ## Customization
 
 ### Separators, Heads, and Tails

--- a/flare.psm1
+++ b/flare.psm1
@@ -1,15 +1,9 @@
 . $PSScriptRoot/promptSymbols.ps1
 
-# Shared dictionary for background job to store results
-$global:flare_resultCache = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
+# Prompt results are applied only on the interactive runspace.
+$global:flare_resultCache = @{}
 
-# Cache for what was last rendered, to be used to compare with result cache
-$global:flare_lastRenderCache = @{}
-
-# Last refresh time for fast pieces that update the cache synchronously.
-$global:flare_fastRefreshTimestamps = [System.Collections.Concurrent.ConcurrentDictionary[string, datetime]]::new()
-
-# Items we can calculate on the main thread, but should also ignore when comparing changes from the background job
+# Items calculated on the interactive runspace rather than the slow refresh worker
 $global:flare_mainThread = @('os', 'date', 'lastCommand', 'pwd')
 
 # Fast pieces that should refresh every prompt because their state can change without touching prompt caches.
@@ -17,15 +11,12 @@ if ($null -eq $global:flare_alwaysRefreshFastPieces) {
     $global:flare_alwaysRefreshFastPieces = @('git')
 }
 
-# Use a concurrent collection to track all background jobs
-$global:flare_backgroundJobs = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
-
-# Background prompt refreshes are best-effort; don't let slow pieces stack up.
-$global:flare_backgroundJobTimeout ??= [TimeSpan]::FromSeconds(10)
-
 $global:flare_lastDirectory = $null
 
 $global:flare_redrawing = $false
+
+$script:flare_nextRefreshRequestId = 0
+$script:flare_latestRefreshRequestId = 0
 
 $defaultStyle = "`e[0m"
 $foregroundStyles = [ordered]@{
@@ -71,7 +62,19 @@ $backgroundStyles = [ordered]@{
 $escapeRegex = "(`e\[\d+\w)"
 
 . $PSScriptRoot/utils/invokeUtils.ps1
+foreach ($pieceFile in Get-ChildItem (Join-Path $PSScriptRoot 'pieces') -Filter '*.ps1' -File) {
+    . $pieceFile.FullName
+}
+. $PSScriptRoot/utils/refreshWorker.ps1
 
+<#
+.SYNOPSIS
+Renders the configured left-side prompt pieces.
+.PARAMETER Parts
+Cached piece values keyed by piece name.
+.OUTPUTS
+System.String
+#>
 function Get-LeftPrompt {
     param(
         [Parameter(Mandatory = $true)]
@@ -104,6 +107,14 @@ function Get-LeftPrompt {
     return $left
 }
 
+<#
+.SYNOPSIS
+Renders the configured right-side prompt pieces.
+.PARAMETER Parts
+Cached piece values keyed by piece name.
+.OUTPUTS
+System.String
+#>
 function Get-RightPrompt {
     param(
         [Parameter(Mandatory = $true)]
@@ -135,6 +146,12 @@ function Get-RightPrompt {
     return $right
 }
 
+<#
+.SYNOPSIS
+Renders the bottom prompt line and command-status arrow.
+.OUTPUTS
+System.String
+#>
 function Get-PromptLine {
     # Check if the last command was successful
     # Get exit status from command history if available
@@ -149,6 +166,14 @@ function Get-PromptLine {
     return "$defaultStyle$global:flare_bottomPrefix$($promptColor)$($global:flare_promptArrow * ($nestedPromptLevel + 1))$defaultStyle"
 }
 
+<#
+.SYNOPSIS
+Extracts the fast Git metadata portion of a rendered Git value.
+.PARAMETER Value
+The rendered Git piece value, optionally including slow status counts.
+.OUTPUTS
+System.String
+#>
 function Get-FlareGitMetadataPrefix {
     param([string]$Value)
 
@@ -159,14 +184,23 @@ function Get-FlareGitMetadataPrefix {
     return ($Value -replace ' (?:⇣|⇡|\*|~|\+|!|\?)\d+(?: .*)?$', '')
 }
 
+<#
+.SYNOPSIS
+Evaluates synchronous and fast prompt pieces and updates the render cache.
+.OUTPUTS
+None
+#>
 function Update-MainThreadPieces {
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
     # Find the intersection of all prompt pieces and main thread items
     $mainThreadPieces = $allPieces | Where-Object { $_ -in $global:flare_mainThread }
-    $mainThreadPieces += $allPieces | Where-Object {
+    $fastPieceCandidates = $allPieces | Where-Object {
         ($_ -notin $global:flare_mainThread) -and
         (($_ -in $global:flare_alwaysRefreshFastPieces) -or (-not $global:flare_resultCache.ContainsKey($_)))
-    } | ForEach-Object { "${_}_fast" }
+    }
+    $mainThreadPieces += $fastPieceCandidates |
+        Where-Object { Test-Path (Join-Path $PSScriptRoot "pieces/${_}_fast.ps1") } |
+        ForEach-Object { "${_}_fast" }
     $mainThreadPieces = $mainThreadPieces | Select-Object -Unique
 
     $mainThreadResults = Get-PromptPieceResults -Pieces $mainThreadPieces
@@ -179,121 +213,58 @@ function Update-MainThreadPieces {
             # Most fast results are fallbacks; selected pieces use them for cheap, synchronous freshness.
             if (($piece -in $global:flare_alwaysRefreshFastPieces) -or (-not $global:flare_resultCache.ContainsKey($piece))) {
                 $fastResult = $mainThreadResults[$pieceFast]
-                $cachedResult = $null
                 if (
                     ($piece -eq 'git') -and
                     $fastResult -and
-                    $global:flare_resultCache.TryGetValue($piece, [ref]$cachedResult) -and
-                    ((Get-FlareGitMetadataPrefix $cachedResult) -eq $fastResult)
+                    $global:flare_resultCache.ContainsKey($piece) -and
+                    ((Get-FlareGitMetadataPrefix $global:flare_resultCache[$piece]) -eq $fastResult)
                 ) {
                     # Keep completed background status counts when only cheap git metadata was refreshed.
                 }
-                else {
+                elseif ($fastResult) {
                     $global:flare_resultCache[$piece] = $fastResult
                 }
-                if ($piece -in $global:flare_alwaysRefreshFastPieces) {
-                    $global:flare_fastRefreshTimestamps[$piece] = Get-Date
+                else {
+                    $global:flare_resultCache.Remove($piece)
                 }
             }
         }
-        else {
+        elseif ($mainThreadResults[$piece]) {
             $global:flare_resultCache[$piece] = $mainThreadResults[$piece]
+        }
+        else {
+            $global:flare_resultCache.Remove($piece)
         }
     }
 }
 
+<#
+.SYNOPSIS
+Submits the current slow-piece snapshot to the durable refresh worker.
+.OUTPUTS
+None
+#>
 function Update-BackgroundThreadPieces {
     $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
-    # Find the intersection of all prompt pieces and main thread items
     $backgroundThreadPieces = $allPieces | Where-Object { $_ -notin $global:flare_mainThread }
     if ($backgroundThreadPieces.Count -eq 0) {
         return
     }
 
-    # Capture the working directory at the time the job is created.
-    # Background jobs run in another runspace and may not inherit the caller's location,
-    # which can cause pieces like `git` to be computed for the wrong directory.
-    $workingDirectory = $PWD.Path
-
-    # Generate a timestamp for this job
-    $timestamp = Get-Date
-
-    $hasActiveCurrentDirectoryJob = $false
-    $jobsToKeep = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
-    foreach ($existingJob in $global:flare_backgroundJobs) {
-        if (-not (Test-FlareBackgroundJobTerminalState $existingJob)) {
-            $jobWorkingDirectoryProperty = $existingJob.PSObject.Properties['WorkingDirectory']
-            $jobTimestampProperty = $existingJob.PSObject.Properties['Timestamp']
-            $jobWorkingDirectory = if ($jobWorkingDirectoryProperty) { $jobWorkingDirectoryProperty.Value } else { $null }
-            $jobTimestamp = if ($jobTimestampProperty) { $jobTimestampProperty.Value } else { $timestamp }
-
-            if (
-                ($jobWorkingDirectory -eq $workingDirectory) -and
-                ($global:flare_backgroundJobTimeout -gt [TimeSpan]::Zero) -and
-                (($timestamp - $jobTimestamp) -gt $global:flare_backgroundJobTimeout)
-            ) {
-                try {
-                    Stop-Job -Job $existingJob -ErrorAction SilentlyContinue
-                    Remove-Job -Job $existingJob -Force -ErrorAction SilentlyContinue
-                }
-                catch {
-                    # Ignore failures; the next idle cleanup can handle jobs that already changed state.
-                }
-                continue
-            }
-
-            if ($jobWorkingDirectory -eq $workingDirectory) {
-                $hasActiveCurrentDirectoryJob = $true
-            }
-        }
-
-        $jobsToKeep.Add($existingJob)
-    }
-    $global:flare_backgroundJobs = $jobsToKeep
-
-    if ($hasActiveCurrentDirectoryJob) {
-        return
-    }
-
-    $job = Start-ThreadJob -Name "Flare Background Update $(Get-Date -Format 'HH:mm:ss.fff')" -ScriptBlock {
-        param($pieces, $results, $timestamp, $workingDirectory)
-        Write-Output "Updating background pieces: $pieces at timestamp $timestamp"
-        . $using:PSScriptRoot/utils/invokeUtils.ps1
-
-        # Ensure piece evaluation happens in the directory that created the job.
-        try {
-            if ($workingDirectory) {
-                Set-Location -LiteralPath $workingDirectory -ErrorAction Stop
-            }
-        }
-        catch {
-            # If we can't cd (directory removed, permissions, etc.), continue. Pieces should fail closed.
-        }
-
-        $piecesResults = Get-PromptPieceResults -Pieces $pieces -PiecesPath $using:PSScriptRoot/pieces
-
-        # Create a results package with timestamp
-        $resultsPackage = @{
-            Timestamp        = $timestamp
-            WorkingDirectory = $workingDirectory
-            Results          = @{}
-        }
-
-        foreach ($piece in $pieces) {
-            Write-Output "Piece: $piece, Result: $($piecesResults[$piece])"
-            $resultsPackage.Results[$piece] = $piecesResults[$piece]
-        }
-
-        # Store the entire package
-        $results["_package_$timestamp"] = $resultsPackage
-    } -ArgumentList $backgroundThreadPieces, $global:flare_resultCache, $timestamp, $workingDirectory
-
-    # Add the new job and its timestamp to our tracking collection
-    $job | Add-Member -NotePropertyName Timestamp -NotePropertyValue $timestamp
-    $job | Add-Member -NotePropertyName WorkingDirectory -NotePropertyValue $workingDirectory
-    $global:flare_backgroundJobs.Add($job)
+    $script:flare_latestRefreshRequestId = Send-FlareRefreshRequest `
+        -WorkingDirectory $PWD.Path `
+        -Pieces $backgroundThreadPieces `
+        -ModuleRoot $PSScriptRoot
 }
 
+<#
+.SYNOPSIS
+Builds the top prompt line from current fast and cached slow results.
+.PARAMETER DisableBackground
+Prevents a new slow refresh request, such as during an idle redraw.
+.OUTPUTS
+System.String
+#>
 function Get-PromptTopLine {
     param(
         [bool]$DisableBackground = $false
@@ -305,15 +276,8 @@ function Get-PromptTopLine {
     }
 
     $results = @{}
-    # Take a snapshot of keys to avoid enumeration issues with concurrent modifications
-    foreach ($piece in @($global:flare_resultCache.Keys)) {
-        # Skip our package keys when building prompt data
-        if (-not $piece.StartsWith('_package_')) {
-            $value = $null
-            if ($global:flare_resultCache.TryGetValue($piece, [ref]$value)) {
-                $results[$piece] = $value
-            }
-        }
+    foreach ($piece in $global:flare_resultCache.Keys) {
+        $results[$piece] = $global:flare_resultCache[$piece]
     }
 
     $left = Get-LeftPrompt -Parts $results
@@ -332,198 +296,124 @@ function Get-PromptTopLine {
     }
 }
 
-function Test-FlareBackgroundJobTerminalState {
-    param(
-        [Parameter(Mandatory = $true)]
-        [object]$Job
-    )
+<#
+.SYNOPSIS
+Applies the newest valid worker result and redraws changed prompt content.
+.PARAMETER DisableRedraw
+Applies accepted results without invoking a PSReadLine prompt redraw.
+.OUTPUTS
+System.Boolean
+#>
+function Update-FlareBackgroundResults {
+    param([switch]$DisableRedraw)
 
-    $Job.State -in @(
-        [System.Management.Automation.JobState]::Completed,
-        [System.Management.Automation.JobState]::Failed,
-        [System.Management.Automation.JobState]::Stopped
-    )
-}
+    $currentWorkingDirectory = $PWD.Path
+    $acceptedResult = @(Receive-FlareRefreshResult) |
+        Where-Object {
+            $_.RequestId -eq $script:flare_latestRefreshRequestId -and
+            $_.WorkingDirectory -eq $currentWorkingDirectory
+        } |
+        Select-Object -Last 1
 
-Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
-    # Check if there are any background jobs to process
-    if ($global:flare_backgroundJobs.Count -eq 0) {
-        return
+    if (-not $acceptedResult) {
+        return $false
     }
 
-    # Only terminal jobs are safe to wait on. Queued jobs can sit in NotStarted,
-    # and Wait-Job on those would block the interactive runspace.
-    $completedJobs = $global:flare_backgroundJobs | Where-Object { Test-FlareBackgroundJobTerminalState $_ }
-    if ($completedJobs.Count -eq 0) {
-        return
+    if (-not $acceptedResult.Succeeded) {
+        Write-Debug "Flare background refresh failed: $($acceptedResult.Error)"
+        return $false
     }
 
-    # Find the newest completed job
-    $newestCompletedJob = $completedJobs | Sort-Object -Property Timestamp -Descending | Select-Object -First 1
-
-    # Process the newest job first to get its results
-    if ($newestCompletedJob) {
-        $null = Wait-Job -Job $newestCompletedJob -ErrorAction SilentlyContinue
-
-        # Find and extract the package with the timestamp from the result cache
-        # Take a snapshot of keys to avoid enumeration issues with concurrent modifications
-        $packageKeys = @($global:flare_resultCache.Keys) | Where-Object { $_ -like '_package_*' }
-
-        # Find the newest package for the CURRENT working directory by timestamp.
-        # Without this, a job created in a previous directory can complete later and
-        # overwrite the cache, reintroducing stale data (notably the `git` piece).
-        $newestPackage = $null
-        $newestPackageTimestamp = [DateTime]::MinValue
-
-        $currentWorkingDirectory = (Get-Location).Path
-
-        foreach ($key in $packageKeys) {
-            $package = $null
-            if (-not $global:flare_resultCache.TryGetValue($key, [ref]$package)) {
-                continue
-            }
-            if ($null -eq $package) {
-                continue
-            }
-
-            if ($package.WorkingDirectory -ne $currentWorkingDirectory) {
-                continue
-            }
-
-            if ($package.Timestamp -gt $newestPackageTimestamp) {
-                $newestPackageTimestamp = $package.Timestamp
-                $newestPackage = $package
-            }
-        }
-
-        # Only apply results from the newest completed job
-        if ($newestPackage) {
-            # Apply the results to the main cache
-            foreach ($piece in $newestPackage.Results.Keys) {
-                $lastFastRefresh = $null
-                if ($piece -eq 'git') {
-                    $currentGitValue = $null
-                    $newGitValue = $newestPackage.Results[$piece]
-                    if (
-                        $global:flare_resultCache.TryGetValue($piece, [ref]$currentGitValue) -and
-                        ((Get-FlareGitMetadataPrefix $newGitValue) -ne (Get-FlareGitMetadataPrefix $currentGitValue))
-                    ) {
-                        continue
-                    }
-                }
-                elseif ($global:flare_fastRefreshTimestamps.TryGetValue($piece, [ref]$lastFastRefresh) -and $newestPackage.Timestamp -lt $lastFastRefresh) {
-                    continue
-                }
-
-                $global:flare_resultCache[$piece] = $newestPackage.Results[$piece]
-            }
-
-            # Clean up packages that are no longer needed (including other directories).
-            foreach ($key in $packageKeys) {
-                $null = $global:flare_resultCache.TryRemove($key, [ref]$null)
-            }
-        }
-        else {
-            # No applicable package for the current directory; still clean up packages so
-            # completed jobs from other directories cannot apply later.
-            foreach ($key in $packageKeys) {
-                $null = $global:flare_resultCache.TryRemove($key, [ref]$null)
-            }
-        }
-    }
-
-    # Wait for and clean up all completed jobs
-    foreach ($job in $completedJobs) {
-        $null = Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-    }
-
-    # Remove completed jobs from our tracking collection
-    $newBag = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
-    foreach ($job in ($global:flare_backgroundJobs | Where-Object { -not (Test-FlareBackgroundJobTerminalState $_) })) {
-        $newBag.Add($job)
-    }
-    $global:flare_backgroundJobs = $newBag
-
-    $allPieces = $global:flare_leftPieces + $global:flare_rightPieces
-    $comparisonPieces = $allPieces | Where-Object { $_ -notin $global:flare_mainThread }
-    # Check if there are changes between caches for background pieces
     $hasChanges = $false
-    foreach ($piece in $comparisonPieces) {
-        $cachedValue = $null
-        # Use TryGetValue for atomic check-and-read to avoid race conditions
-        if ($global:flare_resultCache.TryGetValue($piece, [ref]$cachedValue)) {
-            # If piece is in result cache but not in render cache or values differ
-            if ($cachedValue -ne $global:flare_lastRenderCache[$piece]) {
+    foreach ($piece in $acceptedResult.Pieces) {
+        $newValue = $acceptedResult.Results[$piece]
+        if ($newValue) {
+            if (-not $global:flare_resultCache.ContainsKey($piece) -or $global:flare_resultCache[$piece] -ne $newValue) {
                 $hasChanges = $true
-                break
             }
+            $global:flare_resultCache[$piece] = $newValue
+        }
+        elseif ($global:flare_resultCache.ContainsKey($piece)) {
+            $global:flare_resultCache.Remove($piece)
+            $hasChanges = $true
         }
     }
 
-    # Only redraw prompt if changes were detected
-    if ($hasChanges) {
-        # Update the lastRenderCache with current values
-        foreach ($piece in $comparisonPieces) {
-            $cachedValue = $null
-            if ($global:flare_resultCache.TryGetValue($piece, [ref]$cachedValue)) {
-                $global:flare_lastRenderCache[$piece] = $cachedValue
-            }
-        }
-
-        # Redraw the prompt - wrap in try-catch to prevent blocking if PSReadLine is in an inconsistent state
+    if ($hasChanges -and -not $DisableRedraw) {
         $global:flare_redrawing = $true
         try {
             [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
         }
         catch {
-            # Silently ignore - prompt will be redrawn on next command anyway
+            Write-Debug "Flare prompt redraw failed: $($_.Exception.Message)"
         }
-        $global:flare_redrawing = $false
+        finally {
+            $global:flare_redrawing = $false
+        }
     }
+
+    return $hasChanges
 }
 
-# Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -Action {
-#     New-Event -SourceIdentifier Flare.Redraw -Sender $Sender
-# }
+$script:flare_idleCallback = {
+    $null = Update-FlareBackgroundResults
+}
+$script:flare_idleEventJob = Register-EngineEvent `
+    -SourceIdentifier PowerShell.OnIdle `
+    -Action {
+        & $flareIdleCallback
+    }
+$script:flare_idleEventJob.Module.SessionState.PSVariable.Set('flareIdleCallback', $script:flare_idleCallback)
+$script:flare_idleSubscriptionId = Get-EventSubscriber |
+    Where-Object { $_.Action -eq $script:flare_idleEventJob } |
+    Select-Object -ExpandProperty SubscriptionId -First 1
+
+$script:flare_exitCallback = {
+    Stop-FlareRefreshWorker
+}
+$script:flare_exitEventJob = Register-EngineEvent `
+    -SourceIdentifier PowerShell.Exiting `
+    -Action {
+        & $flareExitCallback
+    }
+$script:flare_exitEventJob.Module.SessionState.PSVariable.Set('flareExitCallback', $script:flare_exitCallback)
+$script:flare_exitSubscriptionId = Get-EventSubscriber |
+    Where-Object { $_.Action -eq $script:flare_exitEventJob } |
+    Select-Object -ExpandProperty SubscriptionId -First 1
 
 # Register a cleanup event handler for when the module is removed
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
-    Get-EventSubscriber | Unregister-Event
-    # Clean up all background jobs
-    foreach ($job in $global:flare_backgroundJobs) {
-        Stop-Job -Job $job -ErrorAction SilentlyContinue
-        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+    foreach ($subscriptionId in @($script:flare_idleSubscriptionId, $script:flare_exitSubscriptionId)) {
+        if ($subscriptionId) {
+            Unregister-Event -SubscriptionId $subscriptionId -ErrorAction SilentlyContinue
+        }
     }
-
-    $global:flare_backgroundJobs = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
+    foreach ($eventJob in @($script:flare_idleEventJob, $script:flare_exitEventJob)) {
+        if ($eventJob) {
+            Remove-Job -Job $eventJob -Force -ErrorAction SilentlyContinue
+        }
+    }
+    Stop-FlareRefreshWorker
 }
 
+<#
+.SYNOPSIS
+Renders Flare's two-line PowerShell prompt.
+.DESCRIPTION
+Clears incompatible cache data after directory changes, renders the fast path,
+and submits slow pieces to the background refresh worker.
+.OUTPUTS
+System.String
+#>
 function Prompt {
+    $currentDirectory = $PWD.Path
     if ($global:flare_lastDirectory) {
-        if ($PWD.Path -ne $global:flare_lastDirectory.Path) {
-            # Clear the last render cache when the directory changes
-            $global:flare_lastRenderCache.Clear()
+        if ($currentDirectory -ne $global:flare_lastDirectory) {
             $global:flare_resultCache.Clear()
-            $global:flare_fastRefreshTimestamps.Clear()
-
-            # Cancel any in-flight background jobs created for the previous directory.
-            # If we don't, a slower job can complete after cd and OnIdle can reapply
-            # stale results for the old directory.
-            foreach ($job in $global:flare_backgroundJobs) {
-                try {
-                    Stop-Job -Job $job -ErrorAction SilentlyContinue
-                    Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-                }
-                catch {
-                    # Ignore failures; jobs may have already completed/been removed.
-                }
-            }
-            $global:flare_backgroundJobs = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
         }
     }
 
-    $global:flare_lastDirectory = $PWD
-
+    $global:flare_lastDirectory = $currentDirectory
 
     $topLine = Get-PromptTopLine -DisableBackground $global:flare_redrawing
     $line = Get-PromptLine
@@ -535,37 +425,3 @@ function Prompt {
 
 # Add module exports
 Export-ModuleMember -Function @('Prompt')
-
-# Use Set-PSReadLineKeyHandler to clear the prompt and rewrite the user's input when the user submits a command
-Set-PSReadLineKeyHandler -Key Enter -BriefDescription 'Clear prompt and rewrite input on Enter' -ScriptBlock {
-    # Prepare references for the input line and cursor position
-    $inputLineRef = [ref]''
-    $cursorPositionRef = [ref]0
-
-    # Retrieve the current input from the command line buffer using GetBufferState
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState($inputLineRef, $cursorPositionRef)
-    $inputLine = $inputLineRef.Value
-
-    # Check if the input is multiline
-    if ($inputLine -join '' -match "`n") {
-        # If multiline, invoke the default Enter key behavior without clearing the prompt
-        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-        return
-    }
-
-    # Move the cursor up by two lines to clear the two-line prompt
-    [System.Console]::SetCursorPosition(0, [System.Console]::CursorTop - 1)
-
-    # Get the console width to overwrite the lines with spaces
-    $consoleWidth = [System.Console]::BufferWidth
-
-    # Clear the current line and the next line by overwriting with spaces
-    [System.Console]::Write(' ' * $consoleWidth * 2)
-
-    # Rewrite the user's input prefixed with '>'
-    [System.Console]::SetCursorPosition(0, [System.Console]::CursorTop - 1)
-    Write-Host "$(Get-PromptLine) $($inputLine -join '')" -NoNewline
-
-    # Execute the command by invoking the default Enter key behavior
-    [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-}

--- a/pieces/bun.ps1
+++ b/pieces/bun.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Bun version for a detected Bun project.
+.OUTPUTS
+System.String
+#>
 function flare_bun {
   $bunlockPath = FindFileInParentDirectories -fileName 'bun.lockb'
   $bunfigPath = FindFileInParentDirectories -fileName 'bunfig.toml'

--- a/pieces/date.ps1
+++ b/pieces/date.ps1
@@ -1,3 +1,9 @@
+<#
+.SYNOPSIS
+Shows the current time using Flare's configured date format.
+.OUTPUTS
+System.String
+#>
 function flare_date {
   $global:flare_dateFormat ??= 'HH:mm:ss'
   return Get-Date -Format $global:flare_dateFormat

--- a/pieces/git.ps1
+++ b/pieces/git.ps1
@@ -1,5 +1,14 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows detailed Git branch, operation, divergence, stash, and worktree status.
+.DESCRIPTION
+Runs Git commands to produce the slow-path repository status used to enrich the
+fast Git metadata after the background refresh completes.
+.OUTPUTS
+System.String
+#>
 function flare_git {
     # Check if git command is available
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {

--- a/pieces/git_fast.ps1
+++ b/pieces/git_fast.ps1
@@ -1,5 +1,13 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Locates repository and Git metadata paths without invoking Git.
+.PARAMETER Path
+The directory from which to search for a .git entry.
+.OUTPUTS
+System.Collections.Hashtable
+#>
 function Get-GitRepoInfo {
   param([string]$Path = (Get-Location))
   
@@ -35,6 +43,16 @@ function Get-GitRepoInfo {
   }
 }
 
+<#
+.SYNOPSIS
+Finds a tag that points directly to a commit.
+.PARAMETER GitDir
+The resolved Git metadata directory.
+.PARAMETER CommitHash
+The full commit hash to match against tag references.
+.OUTPUTS
+System.String
+#>
 function Get-TagForCommit {
   param([string]$GitDir, [string]$CommitHash)
   
@@ -72,6 +90,14 @@ function Get-TagForCommit {
   return $null
 }
 
+<#
+.SYNOPSIS
+Reads the active Git operation and its progress from metadata files.
+.PARAMETER GitDir
+The resolved Git metadata directory.
+.OUTPUTS
+System.Collections.Hashtable
+#>
 function Get-GitOperationStatus {
   param([string]$GitDir)
   
@@ -145,6 +171,15 @@ function Get-GitOperationStatus {
   }
 }
 
+<#
+.SYNOPSIS
+Shows Git branch or detached-head metadata without scanning worktree status.
+.DESCRIPTION
+Reads repository metadata files synchronously to provide a fast Git value while
+the background Git piece calculates detailed status counts.
+.OUTPUTS
+System.String
+#>
 function flare_git_fast {
   # Get repository info
   $repoInfo = Get-GitRepoInfo

--- a/pieces/go.ps1
+++ b/pieces/go.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Go version for a detected Go project.
+.OUTPUTS
+System.String
+#>
 function flare_go {
   $goModPath = FindFileInParentDirectories -fileName 'go.mod'
   $mainGoPath = FindFileInParentDirectories -fileName 'main.go'

--- a/pieces/java.ps1
+++ b/pieces/java.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Java version for a detected Maven or Gradle project.
+.OUTPUTS
+System.String
+#>
 function flare_java {
   $pomXmlPath = FindFileInParentDirectories -fileName 'pom.xml'
   $buildGradlePath = FindFileInParentDirectories -fileName 'build.gradle'

--- a/pieces/lastCommand.ps1
+++ b/pieces/lastCommand.ps1
@@ -1,3 +1,9 @@
+<#
+.SYNOPSIS
+Shows the duration of the most recent command when it exceeded 250 milliseconds.
+.OUTPUTS
+System.String
+#>
 function flare_lastCommand {
   $lastCommand = Get-History -Count 1
   if (-not $lastCommand) { return "" }

--- a/pieces/node.ps1
+++ b/pieces/node.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Node.js version for a detected Node.js project.
+.OUTPUTS
+System.String
+#>
 function flare_node {
   $packageJsonPath = FindFileInParentDirectories -fileName 'package.json'
 

--- a/pieces/os.ps1
+++ b/pieces/os.ps1
@@ -1,3 +1,9 @@
+<#
+.SYNOPSIS
+Gets the normalized Linux distribution identifier.
+.OUTPUTS
+System.String
+#>
 function Get-LinuxDistro {
   $script:distro ??= "$(grep '^ID=' /etc/*release | cut -d'=' -f2)".Trim().ToLower()
   if ($script:distro) {
@@ -9,6 +15,12 @@ function Get-LinuxDistro {
 }
 
 
+<#
+.SYNOPSIS
+Shows the icon for the current operating system or Linux distribution.
+.OUTPUTS
+System.String
+#>
 function flare_os {
   if ($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') { return "" }
   if ($IsMacOS) { return "" }

--- a/pieces/pwd.ps1
+++ b/pieces/pwd.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+Shows an abbreviated current working directory.
+.DESCRIPTION
+Replaces the user profile with a tilde and reduces parent directory names to
+their first character while preserving the final directory name.
+.OUTPUTS
+System.String
+#>
 function flare_pwd {
   $currentPath = $executionContext.SessionState.Path.CurrentLocation.ToString()
   $userHome = [Environment]::GetFolderPath('UserProfile')

--- a/pieces/python.ps1
+++ b/pieces/python.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/python_fast.ps1
 
+<#
+.SYNOPSIS
+Shows the Python version and active virtual environment.
+.OUTPUTS
+System.String
+#>
 function flare_python {
   $venv_name = flare_python_fast
   if (-not $venv_name) {

--- a/pieces/python_fast.ps1
+++ b/pieces/python_fast.ps1
@@ -1,3 +1,9 @@
+<#
+.SYNOPSIS
+Shows the active Python virtual-environment name without invoking Python.
+.OUTPUTS
+System.String
+#>
 function flare_python_fast {
   if ($env:VIRTUAL_ENV) {
     $venv_folder = Split-Path -Path $env:VIRTUAL_ENV -Parent

--- a/pieces/rust.ps1
+++ b/pieces/rust.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Rust compiler version for a detected Rust project.
+.OUTPUTS
+System.String
+#>
 function flare_rust {
   $cargoTomlPath = FindFileInParentDirectories -fileName 'Cargo.toml'
   $toolchainPath = FindFileInParentDirectories -fileName 'rust-toolchain.toml'

--- a/pieces/zig.ps1
+++ b/pieces/zig.ps1
@@ -1,5 +1,11 @@
 . $PSScriptRoot/../utils/fileUtils.ps1
 
+<#
+.SYNOPSIS
+Shows the Zig version for a detected Zig project.
+.OUTPUTS
+System.String
+#>
 function flare_zig {
   $buildZigPath = FindFileInParentDirectories -fileName 'build.zig'
   $buildZigZonPath = FindFileInParentDirectories -fileName 'build.zig.zon'

--- a/testBackgroundJobs.ps1
+++ b/testBackgroundJobs.ps1
@@ -1,76 +1,314 @@
 #!/usr/bin/env pwsh
 
-# Validate that the idle redraw handler only processes terminal background jobs.
-# Treating queued jobs as completed can block keyboard input when Wait-Job runs.
+if ($env:FLARE_BACKGROUND_TEST_CHILD -ne '1') {
+    $previousChildMarker = $env:FLARE_BACKGROUND_TEST_CHILD
+    $env:FLARE_BACKGROUND_TEST_CHILD = '1'
+    try {
+        & (Get-Process -Id $PID).Path -NoLogo -NoProfile -File $PSCommandPath
+        $childExitCode = $LASTEXITCODE
+    }
+    finally {
+        if ($null -eq $previousChildMarker) {
+            Remove-Item Env:FLARE_BACKGROUND_TEST_CHILD -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:FLARE_BACKGROUND_TEST_CHILD = $previousChildMarker
+        }
+    }
+
+    if ($childExitCode -ne 0) {
+        exit $childExitCode
+    }
+    return
+}
 
 $module = Import-Module "$PSScriptRoot/flare.psm1" -Force -PassThru -ErrorAction Stop
-
-$testCases = @(
-    @{ State = 'Completed'; Expected = $true },
-    @{ State = 'Failed'; Expected = $true },
-    @{ State = 'Stopped'; Expected = $true },
-    @{ State = 'NotStarted'; Expected = $false },
-    @{ State = 'Running'; Expected = $false },
-    @{ State = 'Blocked'; Expected = $false },
-    @{ State = 'Suspended'; Expected = $false },
-    @{ State = 'Disconnected'; Expected = $false },
-    @{ State = 'Suspending'; Expected = $false },
-    @{ State = 'Stopping'; Expected = $false },
-    @{ State = 'AtBreakpoint'; Expected = $false }
-)
-
 $allTestsPassed = $true
 
-foreach ($testCase in $testCases) {
-    $actual = & $module {
-        param($state)
+function Test-FlareCondition {
+    param(
+        [bool]$Condition,
+        [string]$SuccessMessage,
+        [string]$FailureMessage
+    )
 
-        $jobState = [System.Management.Automation.JobState]::$state
-        Test-FlareBackgroundJobTerminalState ([pscustomobject]@{ State = $jobState })
-    } $testCase.State
-
-    if ($actual -eq $testCase.Expected) {
-        Write-Host "PASS Background job state '$($testCase.State)' classified correctly"
+    if ($Condition) {
+        Write-Host "PASS $SuccessMessage"
     }
     else {
-        Write-Host "FAIL Background job state '$($testCase.State)' expected '$($testCase.Expected)' but got '$actual'" -ForegroundColor Red
-        $allTestsPassed = $false
+        Write-Host "FAIL $FailureMessage" -ForegroundColor Red
+        $script:allTestsPassed = $false
     }
+}
+
+function Receive-FlareResultsUntil {
+    param(
+        [System.Management.Automation.PSModuleInfo]$Module,
+        [long]$RequestId,
+        [int]$TimeoutMilliseconds = 5000
+    )
+
+    $received = @()
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMilliseconds)
+    do {
+        Start-Sleep -Milliseconds 25
+        $received += @(& $Module { Receive-FlareRefreshResult })
+    } until (
+        ($received | Where-Object RequestId -eq $RequestId) -or
+        (Get-Date) -gt $deadline
+    )
+
+    return $received
 }
 
 $originalLeftPieces = @($global:flare_leftPieces)
 $originalRightPieces = @($global:flare_rightPieces)
 $originalPath = $env:PATH
-$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "flare-git-cache-test-$(Get-Random)"
-New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+$originalLocation = Get-Location
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "flare-refresh-worker-test-$(Get-Random)"
+$workerRoot = Join-Path $tempRoot 'worker'
+$firstDirectory = Join-Path $tempRoot 'first'
+$secondDirectory = Join-Path $tempRoot 'second'
 
 try {
-    Push-Location $tempDir
+    New-Item -ItemType Directory -Path (Join-Path $workerRoot 'utils'), (Join-Path $workerRoot 'pieces'), $firstDirectory, $secondDirectory -Force | Out-Null
+    Copy-Item "$PSScriptRoot/utils/invokeUtils.ps1" (Join-Path $workerRoot 'utils/invokeUtils.ps1')
+
+    @'
+function flare_slow {
+    $value = [System.IO.File]::ReadAllText((Join-Path $PWD 'value.txt')).Trim()
+    [System.IO.File]::WriteAllText((Join-Path $PWD 'started.txt'), $value)
+    $delay = [int][System.IO.File]::ReadAllText((Join-Path $PWD 'delay.txt')).Trim()
+    if ($delay -gt 0) {
+        Start-Sleep -Milliseconds $delay
+    }
+    return $value
+}
+'@ | Set-Content -Path (Join-Path $workerRoot 'pieces/slow.ps1') -Encoding utf8
+
+    'first' | Set-Content -Path (Join-Path $firstDirectory 'value.txt') -Encoding utf8
+    '400' | Set-Content -Path (Join-Path $firstDirectory 'delay.txt') -Encoding utf8
+    'second' | Set-Content -Path (Join-Path $secondDirectory 'value.txt') -Encoding utf8
+    '0' | Set-Content -Path (Join-Path $secondDirectory 'delay.txt') -Encoding utf8
+
+    $enterBinding = Get-PSReadLineKeyHandler -Chord Enter
+    Test-FlareCondition `
+        -Condition ($enterBinding.Function -ne 'Clear prompt and rewrite input on Enter') `
+        -SuccessMessage 'Legacy Flare Enter handler is not active' `
+        -FailureMessage 'Legacy Flare Enter handler remained active'
+
+    & $module {
+        $script:flare_refreshResults = [System.Collections.Concurrent.ConcurrentQueue[object]]::new()
+        $script:flare_latestRefreshRequestId = 50
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 50
+                WorkingDirectory = $PWD.Path
+                Pieces           = @('live')
+                Results          = @{ live = 'updated' }
+                Succeeded        = $true
+                Error            = $null
+            })
+    }
+    $null = New-Event -SourceIdentifier PowerShell.OnIdle
+    $idleDeadline = (Get-Date).AddSeconds(3)
+    while ($global:flare_resultCache['live'] -ne 'updated' -and (Get-Date) -lt $idleDeadline) {
+        Start-Sleep -Milliseconds 25
+    }
+    $idleEventErrors = & $module { @($script:flare_idleEventJob.Error).Count }
+    Test-FlareCondition `
+        -Condition ($global:flare_resultCache['live'] -eq 'updated' -and $idleEventErrors -eq 0) `
+        -SuccessMessage 'Idle event applies completed refresh results through the module callback' `
+        -FailureMessage "Idle event left '$($global:flare_resultCache['live'])' with $idleEventErrors errors"
+    Get-Event | Remove-Event -ErrorAction SilentlyContinue
+    $global:flare_resultCache.Remove('live')
+
+    # Drive result application directly so OnIdle cannot race these assertions.
+    & $module {
+        if ($script:flare_idleSubscriptionId) {
+            Unregister-Event -SubscriptionId $script:flare_idleSubscriptionId -ErrorAction SilentlyContinue
+            $script:flare_idleSubscriptionId = $null
+        }
+        if ($script:flare_idleEventJob) {
+            Remove-Job -Job $script:flare_idleEventJob -Force -ErrorAction SilentlyContinue
+            $script:flare_idleEventJob = $null
+        }
+    }
+
+    $firstRequestId = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot $firstDirectory
+
+    $workerIdentity = & $module {
+        [System.Runtime.CompilerServices.RuntimeHelpers]::GetHashCode($script:flare_refreshWorker.PowerShell)
+    }
+
+    $startDeadline = (Get-Date).AddSeconds(2)
+    while (-not (Test-Path (Join-Path $firstDirectory 'started.txt')) -and (Get-Date) -lt $startDeadline) {
+        Start-Sleep -Milliseconds 20
+    }
+
+    Test-FlareCondition `
+        -Condition (Test-Path (Join-Path $firstDirectory 'started.txt')) `
+        -SuccessMessage 'Durable worker started the first refresh' `
+        -FailureMessage 'Durable worker did not start the first refresh'
+
+    'latest' | Set-Content -Path (Join-Path $firstDirectory 'value.txt') -Encoding utf8
+    $submissionTiming = [System.Diagnostics.Stopwatch]::StartNew()
+    $discardedRequestId = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot $firstDirectory
+    $latestRequestId = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot $firstDirectory
+    $submissionTiming.Stop()
+
+    $workerIdentityAfterRequests = & $module {
+        [System.Runtime.CompilerServices.RuntimeHelpers]::GetHashCode($script:flare_refreshWorker.PowerShell)
+    }
+    $coalescedResults = @(Receive-FlareResultsUntil -Module $module -RequestId $latestRequestId)
+    $coalescedIds = @($coalescedResults | ForEach-Object RequestId)
+
+    Test-FlareCondition `
+        -Condition ($submissionTiming.Elapsed.TotalMilliseconds -lt 250) `
+        -SuccessMessage 'New refresh requests remain non-blocking while slow work is active' `
+        -FailureMessage "Submitting refresh requests took $([math]::Round($submissionTiming.Elapsed.TotalMilliseconds, 2)) ms"
+    Test-FlareCondition `
+        -Condition ($workerIdentity -eq $workerIdentityAfterRequests) `
+        -SuccessMessage 'Refresh requests reuse one durable worker' `
+        -FailureMessage 'Refresh requests replaced the worker unexpectedly'
+    Test-FlareCondition `
+        -Condition (($firstRequestId -in $coalescedIds) -and ($latestRequestId -in $coalescedIds) -and ($discardedRequestId -notin $coalescedIds)) `
+        -SuccessMessage 'Busy worker retains only the newest pending refresh' `
+        -FailureMessage "Expected request IDs $firstRequestId and $latestRequestId but received $($coalescedIds -join ', ')"
+
+    $failedRequestId = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot (Join-Path $tempRoot 'missing')
+    $failedResults = @(Receive-FlareResultsUntil -Module $module -RequestId $failedRequestId)
+    $failedResult = $failedResults | Where-Object RequestId -eq $failedRequestId | Select-Object -Last 1
+
+    $recoveryRequestId = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot $secondDirectory
+    $recoveryResults = @(Receive-FlareResultsUntil -Module $module -RequestId $recoveryRequestId)
+    $recoveryResult = $recoveryResults | Where-Object RequestId -eq $recoveryRequestId | Select-Object -Last 1
+    $workerIdentityAfterFailure = & $module {
+        [System.Runtime.CompilerServices.RuntimeHelpers]::GetHashCode($script:flare_refreshWorker.PowerShell)
+    }
+
+    Test-FlareCondition `
+        -Condition ($failedResult -and -not $failedResult.Succeeded -and $failedResult.Error) `
+        -SuccessMessage 'Refresh failures return explicit error results' `
+        -FailureMessage 'Refresh failure did not return an error result'
+    Test-FlareCondition `
+        -Condition ($recoveryResult.Succeeded -and $recoveryResult.Results['slow'] -eq 'second' -and $workerIdentityAfterFailure -eq $workerIdentity) `
+        -SuccessMessage 'Worker continues after a failed refresh' `
+        -FailureMessage 'Worker did not recover after a failed refresh'
+
+    & $module {
+        Stop-FlareRefreshWorker
+        $global:flare_resultCache.Clear()
+        $script:flare_refreshResults = [System.Collections.Concurrent.ConcurrentQueue[object]]::new()
+        $script:flare_latestRefreshRequestId = 100
+    }
+
+    $staleChanged = & $module {
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 99
+                WorkingDirectory = $PWD.Path
+                Pieces           = @('sample')
+                Results          = @{ sample = 'stale' }
+                Succeeded        = $true
+                Error            = $null
+            })
+        Update-FlareBackgroundResults -DisableRedraw
+    }
+
+    $wrongDirectoryChanged = & $module {
+        param($directory)
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 100
+                WorkingDirectory = $directory
+                Pieces           = @('sample')
+                Results          = @{ sample = 'wrong directory' }
+                Succeeded        = $true
+                Error            = $null
+            })
+        Update-FlareBackgroundResults -DisableRedraw
+    } $secondDirectory
+
+    Test-FlareCondition `
+        -Condition (-not $staleChanged -and -not $wrongDirectoryChanged -and -not $global:flare_resultCache.ContainsKey('sample')) `
+        -SuccessMessage 'Obsolete and wrong-directory results are rejected' `
+        -FailureMessage 'An obsolete or wrong-directory result changed the cache'
+
+    $acceptedChanged = & $module {
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 100
+                WorkingDirectory = $PWD.Path
+                Pieces           = @('sample')
+                Results          = @{ sample = 'accepted' }
+                Succeeded        = $true
+                Error            = $null
+            })
+        Update-FlareBackgroundResults -DisableRedraw
+    }
+    $unchangedResult = & $module {
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 100
+                WorkingDirectory = $PWD.Path
+                Pieces           = @('sample')
+                Results          = @{ sample = 'accepted' }
+                Succeeded        = $true
+                Error            = $null
+            })
+        Update-FlareBackgroundResults -DisableRedraw
+    }
+    $removedResult = & $module {
+        $script:flare_refreshResults.Enqueue([pscustomobject]@{
+                RequestId        = 100
+                WorkingDirectory = $PWD.Path
+                Pieces           = @('sample')
+                Results          = @{ sample = '' }
+                Succeeded        = $true
+                Error            = $null
+            })
+        Update-FlareBackgroundResults -DisableRedraw
+    }
+
+    Test-FlareCondition `
+        -Condition ($acceptedChanged -and -not $unchangedResult -and $removedResult -and -not $global:flare_resultCache.ContainsKey('sample')) `
+        -SuccessMessage 'Accepted results redraw only on visible changes and remove empty pieces' `
+        -FailureMessage 'Accepted result change detection or empty-piece removal was incorrect'
+
+    $gitDirectory = Join-Path $tempRoot 'git'
+    New-Item -ItemType Directory -Path $gitDirectory -Force | Out-Null
+    Push-Location $gitDirectory
     git init --quiet
     git config user.name 'Flare Test'
     git config user.email 'test@example.com'
     git checkout -b main 2>$null | Out-Null
-    'Initial commit' | Out-File -FilePath 'README.md' -Encoding utf8
+    'Initial commit' | Set-Content -Path 'README.md' -Encoding utf8
     git add README.md
     git commit -m 'Initial commit' --quiet
 
     $env:PATH = ''
-
     & $module {
         $global:flare_leftPieces = @('git')
         $global:flare_rightPieces = @()
         $global:flare_resultCache.Clear()
-        $global:flare_lastRenderCache.Clear()
-        $global:flare_fastRefreshTimestamps.Clear()
     }
 
     $cleanGitStatus = & $module {
         Update-MainThreadPieces
         $global:flare_resultCache['git']
     }
-
-    'Untracked content' | Out-File -FilePath 'untracked.txt' -Encoding utf8
-
+    'Untracked content' | Set-Content -Path 'untracked.txt' -Encoding utf8
     $untrackedRefreshTiming = [System.Diagnostics.Stopwatch]::StartNew()
     $untrackedGitStatus = & $module {
         Update-MainThreadPieces
@@ -78,45 +316,133 @@ try {
     }
     $untrackedRefreshTiming.Stop()
 
-    if ($cleanGitStatus -match '\?1') {
-        Write-Host "FAIL Clean git prompt unexpectedly reported untracked files: '$cleanGitStatus'" -ForegroundColor Red
-        $allTestsPassed = $false
-    }
-    elseif ($untrackedGitStatus -match '\?') {
-        Write-Host "FAIL Git fast prompt synchronously scanned untracked files: '$untrackedGitStatus'" -ForegroundColor Red
-        $allTestsPassed = $false
-    }
-    elseif ($untrackedRefreshTiming.Elapsed.TotalMilliseconds -gt 250) {
-        Write-Host "FAIL Git fast prompt took $([math]::Round($untrackedRefreshTiming.Elapsed.TotalMilliseconds, 2)) ms after adding untracked files" -ForegroundColor Red
-        $allTestsPassed = $false
-    }
-    else {
-        Write-Host 'PASS Git fast prompt avoids synchronous untracked scans'
-    }
+    Test-FlareCondition `
+        -Condition ($cleanGitStatus -eq 'main' -and $untrackedGitStatus -eq 'main' -and $untrackedRefreshTiming.Elapsed.TotalMilliseconds -lt 250) `
+        -SuccessMessage 'Git fast prompt avoids synchronous untracked scans' `
+        -FailureMessage "Git fast prompt returned '$untrackedGitStatus' in $([math]::Round($untrackedRefreshTiming.Elapsed.TotalMilliseconds, 2)) ms"
 
     $preservedGitStatus = & $module {
         $global:flare_resultCache['git'] = 'main ?1'
         Update-MainThreadPieces
         $global:flare_resultCache['git']
     }
+    Test-FlareCondition `
+        -Condition ($preservedGitStatus -eq 'main ?1') `
+        -SuccessMessage 'Git fast prompt preserves compatible completed status' `
+        -FailureMessage "Git fast prompt dropped compatible cached status: '$preservedGitStatus'"
 
-    if ($preservedGitStatus -eq 'main ?1') {
-        Write-Host 'PASS Git fast prompt preserves completed background status'
+    Pop-Location
+    $env:PATH = $originalPath
+
+    '5000' | Set-Content -Path (Join-Path $firstDirectory 'delay.txt') -Encoding utf8
+    Remove-Item (Join-Path $firstDirectory 'started.txt') -ErrorAction SilentlyContinue
+    $null = & $module {
+        param($root, $directory)
+        Send-FlareRefreshRequest -WorkingDirectory $directory -Pieces @('slow') -ModuleRoot $root
+    } $workerRoot $firstDirectory
+    $stopStartDeadline = (Get-Date).AddSeconds(2)
+    while (-not (Test-Path (Join-Path $firstDirectory 'started.txt')) -and (Get-Date) -lt $stopStartDeadline) {
+        Start-Sleep -Milliseconds 20
     }
-    else {
-        Write-Host "FAIL Git fast prompt dropped cached background status. Actual: '$preservedGitStatus'" -ForegroundColor Red
-        $allTestsPassed = $false
+
+    $removeTiming = [System.Diagnostics.Stopwatch]::StartNew()
+    Remove-Module flare -Force
+    $removeTiming.Stop()
+
+    Test-FlareCondition `
+        -Condition ($removeTiming.Elapsed.TotalMilliseconds -lt 500) `
+        -SuccessMessage 'Module removal does not wait for active slow work' `
+        -FailureMessage "Module removal took $([math]::Round($removeTiming.Elapsed.TotalMilliseconds, 2)) ms"
+
+    $module = Import-Module "$PSScriptRoot/flare.psm1" -Force -PassThru -ErrorAction Stop
+    $cleanupDeadline = (Get-Date).AddSeconds(3)
+    do {
+        Start-Sleep -Milliseconds 25
+        $stoppingWorkerCount = & $module {
+            Remove-FlareStoppedRefreshWorkers
+            $global:flare_stoppingWorkers.Count
+        }
+    } until ($stoppingWorkerCount -eq 0 -or (Get-Date) -gt $cleanupDeadline)
+    Test-FlareCondition `
+        -Condition ($stoppingWorkerCount -eq 0) `
+        -SuccessMessage 'Asynchronously stopped workers are eventually disposed' `
+        -FailureMessage "$stoppingWorkerCount stopped workers remained undisposed"
+
+    $firstSubscriptionId = & $module { $script:flare_idleSubscriptionId }
+    $firstExitSubscriptionId = & $module { $script:flare_exitSubscriptionId }
+    $firstSubscriberCount = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $firstSubscriptionId).Count
+    $firstExitSubscriberCount = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $firstExitSubscriptionId).Count
+    $module = Import-Module "$PSScriptRoot/flare.psm1" -Force -PassThru -ErrorAction Stop
+    $secondSubscriptionId = & $module { $script:flare_idleSubscriptionId }
+    $secondExitSubscriptionId = & $module { $script:flare_exitSubscriptionId }
+    $oldSubscriberCountAfterReload = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $firstSubscriptionId).Count
+    $oldExitSubscriberCountAfterReload = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $firstExitSubscriptionId).Count
+    $secondSubscriberCount = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $secondSubscriptionId).Count
+    $secondExitSubscriberCount = @(Get-EventSubscriber | Where-Object SubscriptionId -eq $secondExitSubscriptionId).Count
+
+    Test-FlareCondition `
+        -Condition (
+            $firstSubscriberCount -eq 1 -and
+            $firstExitSubscriberCount -eq 1 -and
+            $oldSubscriberCountAfterReload -eq 0 -and
+            $oldExitSubscriberCountAfterReload -eq 0 -and
+            $secondSubscriberCount -eq 1 -and
+            $secondExitSubscriberCount -eq 1
+        ) `
+        -SuccessMessage 'Module reload replaces its idle and exit subscriptions' `
+        -FailureMessage "Module reload left idle=$oldSubscriberCountAfterReload/$secondSubscriberCount and exit=$oldExitSubscriberCountAfterReload/$secondExitSubscriberCount subscriptions"
+
+    Set-PSReadLineKeyHandler -Key Enter -BriefDescription 'Flare test custom Enter' -ScriptBlock {
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
     }
+    $module = Import-Module "$PSScriptRoot/flare.psm1" -Force -PassThru -ErrorAction Stop
+    $customEnterBinding = Get-PSReadLineKeyHandler -Chord Enter
+    Test-FlareCondition `
+        -Condition ($customEnterBinding.Function -eq 'Flare test custom Enter') `
+        -SuccessMessage 'Module import preserves user-defined Enter bindings' `
+        -FailureMessage "Module import replaced custom Enter binding with '$($customEnterBinding.Function)'"
+
+    $exitProbePath = Join-Path $tempRoot 'exitProbe.ps1'
+    @"
+Import-Module '$($module.Path.Replace("'", "''"))' -Force -ErrorAction Stop
+`$probeModule = Get-Module flare
+`$null = Prompt
+`$deadline = (Get-Date).AddSeconds(10)
+do {
+    Start-Sleep -Milliseconds 25
+    `$resultCount = & `$probeModule { `$script:flare_refreshResults.Count }
+} until (`$resultCount -gt 0 -or (Get-Date) -gt `$deadline)
+exit
+"@ | Set-Content -Path $exitProbePath -Encoding utf8
+
+    $processStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $processStartInfo.FileName = (Get-Process -Id $PID).Path
+    $processStartInfo.UseShellExecute = $false
+    $processStartInfo.ArgumentList.Add('-NoLogo')
+    $processStartInfo.ArgumentList.Add('-NoProfile')
+    $processStartInfo.ArgumentList.Add('-File')
+    $processStartInfo.ArgumentList.Add($exitProbePath)
+    $exitProcess = [System.Diagnostics.Process]::Start($processStartInfo)
+    $exitCompleted = $exitProcess.WaitForExit(15000)
+    if (-not $exitCompleted) {
+        Stop-Process -Id $exitProcess.Id -ErrorAction SilentlyContinue
+    }
+
+    Test-FlareCondition `
+        -Condition ($exitCompleted -and $exitProcess.ExitCode -eq 0) `
+        -SuccessMessage 'Shell exit stops an idle durable worker' `
+        -FailureMessage 'Shell process did not exit within 15 seconds'
 }
 finally {
-    Pop-Location -ErrorAction SilentlyContinue
+    Set-Location $originalLocation -ErrorAction SilentlyContinue
     $env:PATH = $originalPath
     $global:flare_leftPieces = $originalLeftPieces
     $global:flare_rightPieces = $originalRightPieces
     $global:flare_resultCache.Clear()
-    $global:flare_lastRenderCache.Clear()
-    $global:flare_fastRefreshTimestamps.Clear()
-    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    if ($module) {
+        & $module { Stop-FlareRefreshWorker }
+    }
+    Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 if (-not $allTestsPassed) {

--- a/testPiecesTiming.ps1
+++ b/testPiecesTiming.ps1
@@ -134,7 +134,7 @@ catch {
     exit 1
 }
 
-Write-Host 'Testing background job state handling...' -ForegroundColor Cyan
+Write-Host 'Testing background refresh worker...' -ForegroundColor Cyan
 & "$PSScriptRoot/testBackgroundJobs.ps1"
 if (-not $?) {
     exit 1

--- a/testPromptTiming.ps1
+++ b/testPromptTiming.ps1
@@ -25,4 +25,9 @@ Write-Host "  Average: $([math]::Round($avg,2)) ms"
 Write-Host "  Min:     $([math]::Round($min,2)) ms"
 Write-Host "  Max:     $([math]::Round($max,2)) ms"
 
+if ($avg -gt 250) {
+    Write-Host "FAIL Average prompt time exceeded 250 ms" -ForegroundColor Red
+    exit 1
+}
+
 "$(Prompt)"

--- a/utils/fileUtils.ps1
+++ b/utils/fileUtils.ps1
@@ -28,6 +28,16 @@ $global:flare_findFileInParentDirectories ??= {
   return $null
 }
 
+<#
+.SYNOPSIS
+Finds the nearest named file in the current or an ancestor directory.
+.PARAMETER FileName
+The file or directory name to locate.
+.PARAMETER StartDirectory
+The directory where the upward search begins. Defaults to the current location.
+.OUTPUTS
+System.String
+#>
 function FindFileInParentDirectories {
   param (
     [string]$FileName,

--- a/utils/invokeUtils.ps1
+++ b/utils/invokeUtils.ps1
@@ -1,3 +1,22 @@
+if (-not $script:flare_pieceCommands) {
+  $script:flare_pieceCommands = @{}
+}
+
+<#
+.SYNOPSIS
+Invokes one prompt piece by name.
+.DESCRIPTION
+Resolves and caches the piece function, executes it, and optionally appends its
+elapsed time. Missing, hidden, or failed pieces return an empty string.
+.PARAMETER PieceName
+The piece suffix used to resolve a flare_<name> function.
+.PARAMETER PiecesPath
+The directory containing piece scripts.
+.PARAMETER IncludeTime
+Appends elapsed milliseconds to a non-empty result.
+.OUTPUTS
+System.Object
+#>
 function Invoke-FlarePiece {
   param(
     [string]$PieceName,
@@ -5,20 +24,31 @@ function Invoke-FlarePiece {
     [bool]$IncludeTime = $false
   )
   try {
-    # Source the piece script file
-    if (Test-Path "$PiecesPath/$PieceName.ps1") {
-      . "$PiecesPath/$PieceName.ps1"
-    }
-        
-    # Prepare to execute the command
+    $cacheKey = "$PiecesPath::$PieceName"
     $command = "flare_$PieceName"
-    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
-      return ''
+
+    if (-not $script:flare_pieceCommands.ContainsKey($cacheKey)) {
+      $commandInfo = Get-Command $command -CommandType Function -ErrorAction SilentlyContinue
+      if (-not $commandInfo) {
+        $piecePath = Join-Path $PiecesPath "$PieceName.ps1"
+        if (-not (Test-Path $piecePath)) {
+          return ''
+        }
+
+        . $piecePath
+        $commandInfo = Get-Command $command -CommandType Function -ErrorAction SilentlyContinue
+        if (-not $commandInfo) {
+          return ''
+        }
+      }
+
+      $script:flare_pieceCommands[$cacheKey] = $commandInfo
     }
     
     # Time the execution
     $timing = [System.Diagnostics.Stopwatch]::StartNew()
-    $result = & $command -ErrorAction SilentlyContinue
+    $pieceCommand = $script:flare_pieceCommands[$cacheKey]
+    $result = & $pieceCommand -ErrorAction SilentlyContinue
     $timing.Stop()
         
     # Format the result based on user settings
@@ -36,6 +66,18 @@ function Invoke-FlarePiece {
 }
 
 
+<#
+.SYNOPSIS
+Evaluates a collection of prompt pieces.
+.PARAMETER Pieces
+Names of the pieces to evaluate.
+.PARAMETER PiecesPath
+The directory containing piece scripts.
+.PARAMETER IncludeTime
+Appends elapsed milliseconds to each non-empty result.
+.OUTPUTS
+System.Collections.Hashtable
+#>
 function Get-PromptPieceResults {
   param(
     [string[]]$Pieces,

--- a/utils/refreshWorker.ps1
+++ b/utils/refreshWorker.ps1
@@ -1,0 +1,251 @@
+if (-not $global:flare_stoppingWorkers) {
+    $global:flare_stoppingWorkers = [System.Collections.Concurrent.ConcurrentQueue[object]]::new()
+}
+
+<#
+.SYNOPSIS
+Disposes refresh workers whose asynchronous stop has completed.
+.DESCRIPTION
+Retains workers that are still stopping so module removal never waits for slow
+piece evaluation to end.
+.OUTPUTS
+None
+#>
+function Remove-FlareStoppedRefreshWorkers {
+    $workersToCheck = $global:flare_stoppingWorkers.Count
+    for ($i = 0; $i -lt $workersToCheck; $i++) {
+        $stoppingWorker = $null
+        if (-not $global:flare_stoppingWorkers.TryDequeue([ref]$stoppingWorker)) {
+            continue
+        }
+
+        if (-not $stoppingWorker.Completion.IsCompleted) {
+            $global:flare_stoppingWorkers.Enqueue($stoppingWorker)
+            continue
+        }
+
+        try {
+            if ($stoppingWorker.CompletionKind -eq 'Stop') {
+                $stoppingWorker.PowerShell.EndStop($stoppingWorker.Completion)
+            }
+            else {
+                $null = $stoppingWorker.PowerShell.EndInvoke($stoppingWorker.Completion)
+            }
+        }
+        catch {
+            Write-Debug "Flare stopped worker cleanup failed: $($_.Exception.Message)"
+        }
+        finally {
+            $stoppingWorker.PowerShell.Dispose()
+            $stoppingWorker.Requests.Dispose()
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Starts Flare's durable background refresh worker.
+.DESCRIPTION
+Creates one in-process PowerShell pipeline with a bounded request queue and a
+shared result queue. An already-running worker is reused.
+.PARAMETER ModuleRoot
+The Flare module root containing the pieces and utility scripts.
+.OUTPUTS
+None
+#>
+function Start-FlareRefreshWorker {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ModuleRoot
+    )
+
+    Remove-FlareStoppedRefreshWorkers
+
+    if ($script:flare_refreshWorker -and -not $script:flare_refreshWorker.AsyncResult.IsCompleted) {
+        return
+    }
+
+    if ($script:flare_refreshWorker) {
+        Stop-FlareRefreshWorker
+    }
+
+    if (-not $script:flare_refreshResults) {
+        $script:flare_refreshResults = [System.Collections.Concurrent.ConcurrentQueue[object]]::new()
+    }
+
+    $requests = [System.Collections.Concurrent.BlockingCollection[object]]::new(1)
+    $powerShell = [System.Management.Automation.PowerShell]::Create()
+    $workerScript = {
+        param($RequestQueue, $ResultQueue, $Root)
+
+        . (Join-Path $Root 'utils/invokeUtils.ps1')
+        $piecesPath = Join-Path $Root 'pieces'
+        foreach ($pieceFile in Get-ChildItem $piecesPath -Filter '*.ps1' -File) {
+            . $pieceFile.FullName
+        }
+
+        foreach ($request in $RequestQueue.GetConsumingEnumerable()) {
+            try {
+                Set-Location -LiteralPath $request.WorkingDirectory -ErrorAction Stop
+
+                $results = @{}
+                foreach ($piece in $request.Pieces) {
+                    $results[$piece] = Invoke-FlarePiece -PieceName $piece -PiecesPath $piecesPath
+                }
+
+                $ResultQueue.Enqueue([pscustomobject]@{
+                        RequestId        = $request.RequestId
+                        WorkingDirectory = $request.WorkingDirectory
+                        Pieces           = $request.Pieces
+                        Results          = $results
+                        Succeeded        = $true
+                        Error            = $null
+                    })
+            }
+            catch {
+                $ResultQueue.Enqueue([pscustomobject]@{
+                        RequestId        = $request.RequestId
+                        WorkingDirectory = $request.WorkingDirectory
+                        Pieces           = $request.Pieces
+                        Results          = @{}
+                        Succeeded        = $false
+                        Error            = $_.Exception.Message
+                    })
+            }
+        }
+    }
+
+    $null = $powerShell.AddScript($workerScript.ToString()).
+        AddArgument($requests).
+        AddArgument($script:flare_refreshResults).
+        AddArgument($ModuleRoot)
+
+    $script:flare_refreshWorker = [pscustomobject]@{
+        PowerShell  = $powerShell
+        Requests    = $requests
+        AsyncResult = $powerShell.BeginInvoke()
+        ModuleRoot  = $ModuleRoot
+    }
+}
+
+<#
+.SYNOPSIS
+Queues the newest slow-piece refresh request.
+.DESCRIPTION
+Starts the worker if needed, discards any pending request, and enqueues the
+latest working-directory snapshot without interrupting active work.
+.PARAMETER WorkingDirectory
+The directory in which the worker evaluates the pieces.
+.PARAMETER Pieces
+Names of the slow pieces to evaluate.
+.PARAMETER ModuleRoot
+The Flare module root used to initialize the worker.
+.OUTPUTS
+System.Int64
+#>
+function Send-FlareRefreshRequest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Pieces,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ModuleRoot
+    )
+
+    Start-FlareRefreshWorker -ModuleRoot $ModuleRoot
+
+    $script:flare_nextRefreshRequestId += 1
+    $request = [pscustomobject]@{
+        RequestId        = $script:flare_nextRefreshRequestId
+        WorkingDirectory = $WorkingDirectory
+        Pieces           = @($Pieces)
+    }
+
+    $discardedRequest = $null
+    while ($script:flare_refreshWorker.Requests.TryTake([ref]$discardedRequest)) {
+        $discardedRequest = $null
+    }
+
+    $script:flare_refreshWorker.Requests.Add($request)
+    return $request.RequestId
+}
+
+<#
+.SYNOPSIS
+Drains completed refresh results from the worker.
+.OUTPUTS
+System.Management.Automation.PSCustomObject
+#>
+function Receive-FlareRefreshResult {
+    if (-not $script:flare_refreshResults) {
+        return
+    }
+
+    $result = $null
+    while ($script:flare_refreshResults.TryDequeue([ref]$result)) {
+        $result
+        $result = $null
+    }
+}
+
+<#
+.SYNOPSIS
+Requests asynchronous shutdown of Flare's background refresh worker.
+.DESCRIPTION
+Completes the request queue and begins stopping active work without waiting.
+Finished workers are disposed the next time worker state is initialized.
+.OUTPUTS
+None
+#>
+function Stop-FlareRefreshWorker {
+    if (-not $script:flare_refreshWorker) {
+        return
+    }
+
+    $worker = $script:flare_refreshWorker
+    $script:flare_refreshWorker = $null
+    $disposeWorker = $false
+
+    try {
+        if (-not $worker.Requests.IsAddingCompleted) {
+            $worker.Requests.CompleteAdding()
+        }
+
+        if (-not $worker.AsyncResult.IsCompleted) {
+            try {
+                $stopResult = $worker.PowerShell.BeginStop($null, $null)
+                $global:flare_stoppingWorkers.Enqueue([pscustomobject]@{
+                        PowerShell     = $worker.PowerShell
+                        Requests       = $worker.Requests
+                        Completion     = $stopResult
+                        CompletionKind = 'Stop'
+                    })
+            }
+            catch {
+                $global:flare_stoppingWorkers.Enqueue([pscustomobject]@{
+                        PowerShell     = $worker.PowerShell
+                        Requests       = $worker.Requests
+                        Completion     = $worker.AsyncResult
+                        CompletionKind = 'Invoke'
+                    })
+                Write-Debug "Flare refresh worker stop request failed: $($_.Exception.Message)"
+            }
+        }
+        else {
+            $disposeWorker = $true
+            $null = $worker.PowerShell.EndInvoke($worker.AsyncResult)
+        }
+    }
+    catch {
+        Write-Debug "Flare refresh worker cleanup failed: $($_.Exception.Message)"
+    }
+    finally {
+        if ($disposeWorker) {
+            $worker.PowerShell.Dispose()
+            $worker.Requests.Dispose()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace per-refresh `ThreadJob` tracking with one durable in-process runspace and latest-only request coalescing
- apply correlated results on idle, preserve compatible fast-path data, and shut down asynchronously on module removal or shell exit
- warm-load piece functions and add comment-based help across the module, utilities, and prompt pieces
- expand regression coverage for redraws, stale results, Enter bindings, module reloads, and process exit

## Validation

- `./testBackgroundJobs.ps1`
- `./testGitStates.ps1`
- `./testPiecesTiming.ps1`
- `./testPromptTiming.ps1`